### PR TITLE
Update preview.yml (Fix Node.js warnings)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,30 +13,27 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Install the latest toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: x86_64-unknown-linux-musl
-        default: true
-        override: true
+      run: |
+        rustup update
+        rustup target add x86_64-unknown-linux-musl
 
     - name: Install musl
       run: sudo apt-get install -y musl-tools
 
     - name: Run tests
-      run: cargo test --release --verbose
-      
+      run: cargo test --release --target=x86_64-unknown-linux-musl --verbose
+
     - name: Build
-      run: cargo build --release --verbose
-      
+      run: cargo build --release --target=x86_64-unknown-linux-musl --verbose
+
     - name: Create preview release
-      uses: marvinpinto/action-automatic-releases@latest
+      uses: softprops/action-gh-release@v2
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: 'preview'
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        tag_name: 'preview'
         prerelease: true
-        title: 'preview'
+        name: 'preview'
         files: 'target/x86_64-unknown-linux-musl/release/btcmap-api'


### PR DESCRIPTION
Changes:
Updated [actions/checkout](https://github.com/actions/checkout) to v4 (v3 use EOL Node.js 16)
Removed deprecated and unsupported [actions-rs/toolchain](https://github.com/actions-rs/toolchain) (EOL Node.js 16)
Replaced deprecated and unsupported [marvinpinto/action-automatic-releases](https://github.com/marvinpinto/action-automatic-releases) with [softprops/action-gh-release](https://github.com/softprops/action-gh-release)

Node.js EOL (End Of Life) - [GitHub.Blog](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)