### PR TITLE
amenity:bureau_de_change => category 'atm'

### DIFF
--- a/src/rpc/generate_element_categories.rs
+++ b/src/rpc/generate_element_categories.rs
@@ -63,7 +63,9 @@ impl OverpassElement {
 
         let mut category = "other";
 
-        if amenity == "atm" {
+        if amenity == "atm"
+            || amenity == "bureau_de_change" // practical assumption of exchange offices are regarded as much useful as atms 
+        {
             category = "atm";
         }
 


### PR DESCRIPTION
throwing amenity:bureau_de_change to category 'atm' for the purpose of default exclusion on the map #37 

maybe to the effect that https://github.com/teambtcmap/btcmap.org/issues/56 is rather "patched again" than "properly solved".