### PR TITLE
Add Nostr auth via NIP-98 for identity linking and token retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+opencode.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +597,7 @@ dependencies = [
  "include_dir",
  "matrix-sdk",
  "names",
+ "nostr",
  "regex",
  "reqwest",
  "rusqlite",
@@ -1594,6 +1629,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,6 +2071,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,6 +2505,30 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nostr"
+version = "0.44.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
+dependencies = [
+ "base64",
+ "bech32",
+ "bip39",
+ "bitcoin_hashes",
+ "cbc",
+ "chacha20",
+ "chacha20poly1305",
+ "getrandom 0.2.17",
+ "hex",
+ "instant",
+ "scrypt",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+ "url",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -3467,10 +3553,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "password-hash",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "rand 0.8.5",
+ "secp256k1-sys",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,3 +101,7 @@ strum = { version = "0.28.0", features = ["derive"] }
 tokio = "1.48.0"
 
 names = "0.14.0"
+
+# Used for NIP-98 HTTP auth (Nostr event verification)
+# https://github.com/rust-nostr/nostr
+nostr = { version = "0.44.2", default-features = false, features = ["std"] }

--- a/docs/rest/v4/README.md
+++ b/docs/rest/v4/README.md
@@ -10,7 +10,8 @@ The latest and recommended version of the BTCMap API, offering improved performa
 - **[Place Comments](place-comments.md)** - Fetch place comment quotes and submit comment intents.
 - **[Events](events.md)** - Fetch events.
 - **[Invoices](invoices.md)** - Check invoice status for boosts, comments and other paywalled features.
-- **[Users](users.md)** - Get authenticated user information.  
+- **[Users](users.md)** - Get authenticated user information, manage Nostr identity.
+- **[Nostr](nostr.md)** - Authenticate with Nostr (NIP-98) to obtain API tokens.
 ### Planned
 - **[Areas](areas.md)** - Fetch areas.
 ### Proposed

--- a/docs/rest/v4/nostr.md
+++ b/docs/rest/v4/nostr.md
@@ -1,0 +1,59 @@
+# Nostr REST API (v4)
+
+This document describes the Nostr authentication endpoints in REST API v4.
+
+## Available Endpoints
+
+- [Create Token with Nostr](#create-token-with-nostr)
+
+### Create Token with Nostr
+
+Obtain a BTC Map API Bearer token by authenticating with a [NIP-98](https://github.com/nostr-protocol/nips/blob/master/98.md) signed Nostr event. This is the "login with Nostr" flow -- no password is required.
+
+**Prerequisites**: The Nostr pubkey used to sign the event must already be linked to a BTC Map account via `PUT /v4/users/me/nostr` (see [Users API](users.md#linkupdate-nostr-identity)).
+
+The NIP-98 event must have:
+- `kind`: 27235
+- `u` tag: the exact request URL (e.g., `https://api.btcmap.org/v4/nostr/token`)
+- `method` tag: `POST`
+- `created_at`: within 60 seconds of server time
+- Valid Schnorr signature
+
+#### Example Request
+
+```bash
+curl -X POST https://api.btcmap.org/v4/nostr/token \
+  -H "Authorization: Nostr <base64-encoded NIP-98 event>"
+```
+
+Note: The `Authorization` header uses the `Nostr` scheme (not `Bearer`), as specified by NIP-98.
+
+#### Response
+
+| Code | Description |
+|------|-------------|
+| 200  | Success - Returns a Bearer token |
+| 400  | Bad Request - NIP-98 verification failed or no linked account |
+| 401  | Unauthorized - Missing or invalid Authorization: Nostr header |
+
+##### Example Response (200 OK)
+
+```json
+{
+  "token": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| token | String | Bearer token (UUID v4) for authenticating subsequent API requests |
+
+#### Usage Flow
+
+```
+1. User has a BTC Map account with a linked Nostr pubkey
+2. User's Nostr client signs a NIP-98 event for POST https://api.btcmap.org/v4/nostr/token
+3. Client sends: POST /v4/nostr/token with Authorization: Nostr <base64>
+4. Server verifies event, looks up user by pubkey, returns Bearer token
+5. Client uses Bearer token for all subsequent API calls
+```

--- a/docs/rest/v4/users.md
+++ b/docs/rest/v4/users.md
@@ -9,6 +9,9 @@ This document describes the endpoints for interacting with users in REST API v4.
 - [Create Token](#create-token)
 - [Change Password](#change-password)
 - [Update Username](#update-username)
+- [Get Nostr Identity](#get-nostr-identity)
+- [Link/Update Nostr Identity](#linkupdate-nostr-identity)
+- [Remove Nostr Identity](#remove-nostr-identity)
 
 ### Get Authenticated User
 
@@ -34,7 +37,8 @@ curl https://api.btcmap.org/v4/users/me \
 {
   "id": 123,
   "name": "satoshi",
-  "roles": ["user", "admin"]
+  "roles": ["user", "admin"],
+  "npub": "abc123def456..."
 }
 ```
 
@@ -43,6 +47,7 @@ curl https://api.btcmap.org/v4/users/me \
 | id    | Number | User ID |
 | name  | String | Username |
 | roles | Array  | List of user roles (e.g., "user", "admin", "root") |
+| npub  | String or null | Linked Nostr public key (hex-encoded), omitted if not linked |
 
 ### Create User
 
@@ -209,3 +214,109 @@ curl -X PUT https://api.btcmap.org/v4/users/me/username \
 | id    | Number | User ID |
 | name  | String | Updated username |
 | roles | Array  | List of user roles |
+
+### Get Nostr Identity
+
+Returns the Nostr public key linked to the authenticated user's account. Requires a valid Bearer token.
+
+#### Example Request
+
+```bash
+curl https://api.btcmap.org/v4/users/me/nostr \
+  -H "Authorization: Bearer <your-token>"
+```
+
+#### Response
+
+| Code | Description |
+|------|-------------|
+| 200  | Success - Returns linked Nostr pubkey |
+| 401  | Unauthorized - Missing or invalid token |
+
+##### Example Response (200 OK)
+
+```json
+{
+  "npub": "abc123def456..."
+}
+```
+
+If no Nostr identity is linked, `npub` will be `null`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| npub  | String or null | Hex-encoded Nostr public key, or null if not linked |
+
+### Link/Update Nostr Identity
+
+Links or updates the Nostr identity for the authenticated user. The request body must contain a base64-encoded [NIP-98](https://github.com/nostr-protocol/nips/blob/master/98.md) kind 27235 event signed by the Nostr key to link.
+
+The NIP-98 event must have:
+- `kind`: 27235
+- `u` tag: the exact request URL (e.g., `https://api.btcmap.org/v4/users/me/nostr`)
+- `method` tag: `PUT`
+- `created_at`: within 60 seconds of server time
+- Valid Schnorr signature
+
+Each Nostr pubkey can only be linked to one BTC Map account (and vice versa).
+
+#### Example Request
+
+```bash
+curl -X PUT https://api.btcmap.org/v4/users/me/nostr \
+  -H "Authorization: Bearer <your-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"nostr_event": "<base64-encoded NIP-98 event>"}'
+```
+
+#### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| nostr_event | String | Yes | Base64-encoded NIP-98 kind 27235 event |
+
+#### Response
+
+| Code | Description |
+|------|-------------|
+| 200  | Success - Nostr identity linked/updated |
+| 400  | Bad Request - NIP-98 verification failed or pubkey already linked |
+| 401  | Unauthorized - Missing or invalid Bearer token |
+
+##### Example Response (200 OK)
+
+```json
+{
+  "npub": "abc123def456..."
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| npub  | String | Hex-encoded Nostr public key that was linked |
+
+### Remove Nostr Identity
+
+Removes the Nostr identity linked to the authenticated user's account. Requires a valid Bearer token.
+
+#### Example Request
+
+```bash
+curl -X DELETE https://api.btcmap.org/v4/users/me/nostr \
+  -H "Authorization: Bearer <your-token>"
+```
+
+#### Response
+
+| Code | Description |
+|------|-------------|
+| 200  | Success - Nostr identity removed |
+| 400  | Bad Request - No Nostr identity linked |
+| 401  | Unauthorized - Missing or invalid token |
+
+##### Example Response (200 OK)
+
+```json
+{
+  "npub": null
+}

--- a/docs/rpc/README.md
+++ b/docs/rpc/README.md
@@ -8,6 +8,7 @@ The RPC API provides a [JSON-RPC 2.0](https://www.jsonrpc.org/specification) int
 
 - [Public Methods](public-methods.md) - Methods for client apps to use
 - [Auth](auth.md) - Methods for admins to manage passwords.
+- [Nostr](nostr.md) - Link Nostr identity and authenticate via NIP-98
 - [Element Methods](element-methods.md) - Methods for working with map elements
 - [Area Methods](area-methods.md) - Methods for working with geographic areas
 - [User Methods](user-methods.md) - Methods for working with user data

--- a/docs/rpc/auth/whoami.md
+++ b/docs/rpc/auth/whoami.md
@@ -12,7 +12,8 @@ This method can help you if you forgot your name.
   "roles": [
     "root"
   ],
-  "created_at": "2024-06-13T10:33:73Z"
+  "created_at": "2024-06-13T10:33:73Z",
+  "npub": "abc123def456..."
 }
 ```
 

--- a/docs/rpc/nostr.md
+++ b/docs/rpc/nostr.md
@@ -1,0 +1,231 @@
+# Nostr RPCs
+
+These methods allow linking a Nostr identity to a BTC Map account and authenticating via [NIP-98](https://github.com/nostr-protocol/nips/blob/master/98.md) HTTP Auth.
+
+## Table of Contents
+
+- [link_nostr_identity](#link_nostr_identity)
+- [update_nostr_identity](#update_nostr_identity)
+- [remove_nostr_identity](#remove_nostr_identity)
+- [create_api_key_with_nostr](#create_api_key_with_nostr)
+
+## NIP-98 Event Requirements
+
+For methods that accept a NIP-98 event, the base64-encoded Nostr event must satisfy:
+
+- `kind`: 27235
+- `u` tag: must exactly match the request URL (e.g., `https://api.btcmap.org/rpc`)
+- `method` tag: `POST`
+- `created_at`: within 60 seconds of server time
+- Valid Schnorr signature
+
+## link_nostr_identity
+
+Links a Nostr pubkey to the authenticated user's BTC Map account. Each pubkey can only be linked to one account, and each account can only have one linked pubkey.
+
+**Required Role**: User
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "link_nostr_identity",
+  "params": {
+    "nostr_event": "<base64-encoded NIP-98 kind 27235 event>",
+    "url": "https://api.btcmap.org/rpc"
+  },
+  "id": 1
+}
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| nostr_event | String | Base64-encoded NIP-98 event signed by the Nostr key to link |
+| url | String | The URL the NIP-98 event was signed for (must match the `u` tag) |
+
+### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "npub": "abc123def456..."
+  },
+  "id": 1
+}
+```
+
+### Errors
+
+- User already has a linked Nostr identity (use `update_nostr_identity` instead)
+- Nostr pubkey is already linked to another account
+- NIP-98 event verification failed
+
+### Example
+
+```bash
+curl --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer $ACCESS_TOKEN" \
+  --request POST \
+  --data '{"jsonrpc":"2.0","method":"link_nostr_identity","params":{"nostr_event":"<base64>","url":"https://api.btcmap.org/rpc"},"id":1}' \
+  https://api.btcmap.org/rpc
+```
+
+## update_nostr_identity
+
+Replaces the Nostr pubkey linked to the authenticated user's account with a new one. The NIP-98 event must be signed by the **new** Nostr key.
+
+**Required Role**: User
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "update_nostr_identity",
+  "params": {
+    "nostr_event": "<base64-encoded NIP-98 event signed by NEW key>",
+    "url": "https://api.btcmap.org/rpc"
+  },
+  "id": 1
+}
+```
+
+### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "npub": "newpubkey789..."
+  },
+  "id": 1
+}
+```
+
+### Errors
+
+- No Nostr identity linked (use `link_nostr_identity` first)
+- New pubkey is already linked to another account
+- NIP-98 event verification failed
+
+### Example
+
+```bash
+curl --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer $ACCESS_TOKEN" \
+  --request POST \
+  --data '{"jsonrpc":"2.0","method":"update_nostr_identity","params":{"nostr_event":"<base64>","url":"https://api.btcmap.org/rpc"},"id":1}' \
+  https://api.btcmap.org/rpc
+```
+
+## remove_nostr_identity
+
+Removes the Nostr identity linked to the authenticated user's account.
+
+**Required Role**: User
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "remove_nostr_identity",
+  "id": 1
+}
+```
+
+No params required.
+
+### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "message": "Nostr identity removed"
+  },
+  "id": 1
+}
+```
+
+### Errors
+
+- No Nostr identity linked to this account
+
+### Example
+
+```bash
+curl --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer $ACCESS_TOKEN" \
+  --request POST \
+  --data '{"jsonrpc":"2.0","method":"remove_nostr_identity","id":1}' \
+  https://api.btcmap.org/rpc
+```
+
+## create_api_key_with_nostr
+
+Obtain a BTC Map API Bearer token using NIP-98 Nostr authentication. This is the "login with Nostr" flow -- no password or existing Bearer token is required.
+
+**Authentication**: `Authorization: Nostr <base64-encoded NIP-98 event>` header (not Bearer)
+
+**Required Role**: None (anonymous method)
+
+**Prerequisites**: The Nostr pubkey must already be linked to a BTC Map account via `link_nostr_identity`.
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "create_api_key_with_nostr",
+  "id": 1
+}
+```
+
+No params required. Authentication is via the `Authorization: Nostr` header.
+
+### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "token": "550e8400-e29b-41d4-a716-446655440000",
+    "time_ms": 5
+  },
+  "id": 1
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| token | String | Bearer token (UUID v4) for subsequent API calls |
+| time_ms | Number | Processing time in milliseconds |
+
+### Errors
+
+- Missing or invalid `Authorization: Nostr` header
+- NIP-98 event verification failed
+- No BTC Map account linked to this Nostr pubkey
+
+### Example
+
+```bash
+curl --header 'Content-Type: application/json' \
+  --header "Authorization: Nostr <base64-encoded-nip98-event>" \
+  --request POST \
+  --data '{"jsonrpc":"2.0","method":"create_api_key_with_nostr","id":1}' \
+  https://api.btcmap.org/rpc
+```
+
+### Usage Flow
+
+```
+1. User already has a BTC Map account with linked Nostr pubkey
+2. Nostr client signs a NIP-98 event for POST https://api.btcmap.org/rpc
+3. Send RPC request with Authorization: Nostr <base64>
+4. Server verifies event -> looks up user by pubkey -> returns Bearer token
+5. Use Bearer token for all subsequent API/RPC calls
+```

--- a/docs/rpc/public-methods.md
+++ b/docs/rpc/public-methods.md
@@ -7,6 +7,7 @@ These methods are intended to be used by user-facing apps, such as the Web App, 
 
 - [AddElementComment](#addelementcomment)
 - [BoostElement](#boostelement)
+- [CreateApiKeyWithNostr](#createapikeywithnostr)
 - [GetArea](#getarea)
 - [GetAreaDashboard](#getareadashboard)
 - [GetElement](#getelement)
@@ -440,6 +441,35 @@ Gets quotes for boosting an element for different durations.
     "quote_30d_sat": 1000,
     "quote_90d_sat": 2500,
     "quote_365d_sat": 8000
+  },
+  "id": 1
+}
+```
+
+### CreateApiKeyWithNostr
+
+Obtain a BTC Map API Bearer token using [NIP-98](https://github.com/nostr-protocol/nips/blob/master/98.md) Nostr authentication. No password or existing token required. The Nostr pubkey must be linked to a BTC Map account first (see [Nostr RPCs](nostr.md)).
+
+**Authentication**: `Authorization: Nostr <base64-encoded NIP-98 event>` header
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "create_api_key_with_nostr",
+  "id": 1
+}
+```
+
+### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "token": "550e8400-e29b-41d4-a716-446655440000",
+    "time_ms": 5
   },
   "id": 1
 }

--- a/src/db/main/migrations/99.sql
+++ b/src/db/main/migrations/99.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX user_npub ON "user"(npub) WHERE npub IS NOT NULL;

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,12 +189,16 @@ async fn main() -> Result<()> {
                     .service(scope("activity").service(rest::v4::activity::get))
                     .service(
                         scope("users")
+                            .service(rest::v4::users::get_nostr_identity)
+                            .service(rest::v4::users::put_nostr_identity)
+                            .service(rest::v4::users::delete_nostr_identity)
                             .service(rest::v4::users::me)
                             .service(rest::v4::users::post)
                             .service(rest::v4::users::change_password)
                             .service(rest::v4::users::update_username)
                             .service(rest::v4::users::create_token),
-                    ),
+                    )
+                    .service(scope("nostr").service(rest::v4::nostr::create_token)),
             )
     })
     .client_request_timeout(Duration::from_millis(0))

--- a/src/rest/error.rs
+++ b/src/rest/error.rs
@@ -45,6 +45,10 @@ impl RestApiError {
             "Authentication required".to_string(),
         )
     }
+
+    pub fn unauthorized_with_message(message: impl Into<String>) -> Self {
+        Self::new(RestApiErrorCode::Unauthorized, message)
+    }
 }
 
 #[derive(Debug)]

--- a/src/rest/v4/mod.rs
+++ b/src/rest/v4/mod.rs
@@ -6,6 +6,7 @@ pub mod dashboard;
 pub mod element_issues;
 pub mod events;
 pub mod invoices;
+pub mod nostr;
 pub mod place_boosts;
 pub mod place_comments;
 pub mod places;

--- a/src/rest/v4/nostr.rs
+++ b/src/rest/v4/nostr.rs
@@ -1,0 +1,164 @@
+use crate::db;
+use crate::db::main::MainPool;
+use crate::rest::error::RestApiError;
+use crate::service::nip98;
+use actix_web::http::header;
+use actix_web::post;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::HttpRequest;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize)]
+pub struct TokenResponse {
+    pub token: String,
+}
+
+/// POST /v4/nostr/token
+///
+/// Obtain a BTC Map API token using NIP-98 Nostr auth.
+/// The client sends `Authorization: Nostr <base64-encoded kind 27235 event>`.
+/// The server verifies the event, looks up the user by pubkey, and returns a Bearer token.
+#[post("/token")]
+pub async fn create_token(
+    req: HttpRequest,
+    pool: Data<MainPool>,
+) -> Result<Json<TokenResponse>, RestApiError> {
+    let nostr_payload = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(nip98::extract_nostr_auth)
+        .ok_or_else(|| {
+            RestApiError::unauthorized_with_message(
+                "Missing or invalid Authorization: Nostr header",
+            )
+        })?;
+
+    let url = format!(
+        "{}://{}{}",
+        req.connection_info().scheme(),
+        req.connection_info().host(),
+        req.uri(),
+    );
+
+    let verified = nip98::verify(nostr_payload, &url, "POST")
+        .map_err(|e| RestApiError::invalid_input(format!("NIP-98 verification failed: {e}")))?;
+
+    let user = db::main::user::queries::select_by_npub(&verified.pubkey, &pool)
+        .await
+        .map_err(|_| RestApiError::database())?
+        .ok_or_else(|| {
+            RestApiError::invalid_input("No BTC Map account linked to this Nostr pubkey")
+        })?;
+
+    let token = Uuid::new_v4().to_string();
+    db::main::access_token::queries::insert(user.id, String::new(), token.clone(), vec![], &pool)
+        .await
+        .map_err(|_| RestApiError::database())?;
+
+    Ok(Json(TokenResponse { token }))
+}
+
+#[cfg(test)]
+mod test {
+    use crate::db;
+    use crate::db::main::test::pool;
+    use crate::db::main::user::schema::Role;
+    use crate::Result;
+    use actix_web::http::header;
+    use actix_web::http::StatusCode;
+    use actix_web::test::TestRequest;
+    use actix_web::web::{scope, Data};
+    use actix_web::{test, App};
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use base64::Engine;
+    use nostr::event::EventBuilder;
+    use nostr::key::Keys;
+    use nostr::JsonUtil;
+    use nostr::Kind;
+    use nostr::Tag;
+    use nostr::Timestamp;
+
+    async fn make_nip98_event(keys: &Keys, url: &str, method: &str) -> String {
+        let event = EventBuilder::new(Kind::from_u16(27235), "")
+            .tags(vec![
+                Tag::parse(["u", url]).unwrap(),
+                Tag::parse(["method", method]).unwrap(),
+            ])
+            .custom_created_at(Timestamp::now())
+            .sign(keys)
+            .await
+            .unwrap();
+        BASE64.encode(event.as_json().as_bytes())
+    }
+
+    #[test]
+    async fn create_token_no_auth_header() -> Result<()> {
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool()))
+                .service(scope("/nostr").service(super::create_token)),
+        )
+        .await;
+
+        let req = TestRequest::post().uri("/nostr/token").to_request();
+        let res = test::call_service(&app, req).await;
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+        Ok(())
+    }
+
+    #[test]
+    async fn create_token_no_linked_account() -> Result<()> {
+        let pool = pool();
+        let keys = Keys::generate();
+        let url = "http://localhost:8080/nostr/token";
+        let b64 = make_nip98_event(&keys, url, "POST").await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool))
+                .service(scope("/nostr").service(super::create_token)),
+        )
+        .await;
+
+        let req = TestRequest::post()
+            .uri("/nostr/token")
+            .insert_header((header::AUTHORIZATION, format!("Nostr {b64}")))
+            .to_request();
+        let res = test::call_service(&app, req).await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        Ok(())
+    }
+
+    #[test]
+    async fn create_token_success() -> Result<()> {
+        let pool = pool();
+        let keys = Keys::generate();
+        let pubkey_hex = keys.public_key().to_hex();
+
+        // Create user and link npub
+        let user = db::main::user::queries::insert("nostr_user", "", &pool).await?;
+        db::main::user::queries::set_roles(user.id, &[Role::User], &pool).await?;
+        db::main::user::queries::set_npub(user.id, Some(pubkey_hex), &pool).await?;
+
+        let url = "http://localhost:8080/nostr/token";
+        let b64 = make_nip98_event(&keys, url, "POST").await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool))
+                .service(scope("/nostr").service(super::create_token)),
+        )
+        .await;
+
+        let req = TestRequest::post()
+            .uri("/nostr/token")
+            .insert_header((header::AUTHORIZATION, format!("Nostr {b64}")))
+            .to_request();
+        let res: super::TokenResponse = test::call_and_read_body_json(&app, req).await;
+        assert!(!res.token.is_empty());
+        Ok(())
+    }
+}

--- a/src/rest/v4/users.rs
+++ b/src/rest/v4/users.rs
@@ -3,6 +3,8 @@ use crate::db::main::MainPool;
 use crate::db::{self, main::user::schema::Role};
 use crate::rest::auth::Auth;
 use crate::rest::error::RestApiError;
+use crate::service::nip98;
+use actix_web::delete;
 use actix_web::get;
 use actix_web::http::header;
 use actix_web::post;
@@ -27,6 +29,8 @@ pub struct MeResponse {
     pub id: i64,
     pub name: String,
     pub roles: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub npub: Option<String>,
 }
 
 impl From<&User> for MeResponse {
@@ -35,6 +39,7 @@ impl From<&User> for MeResponse {
             id: user.id,
             name: user.name.clone(),
             roles: user.roles.iter().map(|r| r.to_string()).collect(),
+            npub: user.npub.clone(),
         }
     }
 }
@@ -183,6 +188,97 @@ pub async fn create_token(
     .await
     .map_err(|_| RestApiError::database())?;
     Ok(Json(CreateTokenResponse { token }))
+}
+
+#[derive(Serialize)]
+pub struct NostrIdentityResponse {
+    pub npub: Option<String>,
+}
+
+/// GET /v4/users/me/nostr
+///
+/// Returns the Nostr pubkey linked to the authenticated user.
+#[get("/me/nostr")]
+pub async fn get_nostr_identity(auth: Auth) -> Result<Json<NostrIdentityResponse>, RestApiError> {
+    let user = auth.user.ok_or_else(RestApiError::unauthorized)?;
+    Ok(Json(NostrIdentityResponse { npub: user.npub }))
+}
+
+#[derive(Deserialize)]
+pub struct LinkNostrArgs {
+    pub nostr_event: String,
+}
+
+#[derive(Serialize)]
+pub struct LinkNostrResponse {
+    pub npub: String,
+}
+
+/// PUT /v4/users/me/nostr
+///
+/// Link or update the Nostr identity for the authenticated user.
+/// The request body must contain a base64-encoded NIP-98 kind 27235 event.
+#[put("/me/nostr")]
+pub async fn put_nostr_identity(
+    req: actix_web::HttpRequest,
+    auth: Auth,
+    args: Json<LinkNostrArgs>,
+    pool: Data<MainPool>,
+) -> Result<Json<LinkNostrResponse>, RestApiError> {
+    let user = auth.user.ok_or_else(RestApiError::unauthorized)?;
+
+    let url = format!(
+        "{}://{}{}",
+        req.connection_info().scheme(),
+        req.connection_info().host(),
+        req.uri(),
+    );
+
+    let verified = nip98::verify(&args.nostr_event, &url, "PUT")
+        .map_err(|e| RestApiError::invalid_input(format!("NIP-98 verification failed: {e}")))?;
+
+    // Check if this pubkey is already linked to another account
+    let existing = db::main::user::queries::select_by_npub(&verified.pubkey, &pool)
+        .await
+        .map_err(|_| RestApiError::database())?;
+    if let Some(existing_user) = existing {
+        if existing_user.id != user.id {
+            return Err(RestApiError::invalid_input(
+                "This Nostr pubkey is already linked to another account",
+            ));
+        }
+    }
+
+    db::main::user::queries::set_npub(user.id, Some(verified.pubkey.clone()), &pool)
+        .await
+        .map_err(|_| RestApiError::database())?;
+
+    Ok(Json(LinkNostrResponse {
+        npub: verified.pubkey,
+    }))
+}
+
+/// DELETE /v4/users/me/nostr
+///
+/// Remove the Nostr identity linked to the authenticated user.
+#[delete("/me/nostr")]
+pub async fn delete_nostr_identity(
+    auth: Auth,
+    pool: Data<MainPool>,
+) -> Result<Json<NostrIdentityResponse>, RestApiError> {
+    let user = auth.user.ok_or_else(RestApiError::unauthorized)?;
+
+    if user.npub.is_none() {
+        return Err(RestApiError::invalid_input(
+            "No Nostr identity linked to this account",
+        ));
+    }
+
+    db::main::user::queries::set_npub(user.id, None, &pool)
+        .await
+        .map_err(|_| RestApiError::database())?;
+
+    Ok(Json(NostrIdentityResponse { npub: None }))
 }
 
 #[cfg(test)]

--- a/src/rpc/auth/whoami.rs
+++ b/src/rpc/auth/whoami.rs
@@ -10,6 +10,8 @@ pub struct Res {
     pub roles: Vec<String>,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub npub: Option<String>,
 }
 
 pub async fn run(user: &User) -> Result<Res> {
@@ -18,6 +20,7 @@ pub async fn run(user: &User) -> Result<Res> {
         name: user.name.clone(),
         roles,
         created_at: OffsetDateTime::parse(&user.created_at, &Rfc3339)?,
+        npub: user.npub.clone(),
     })
 }
 

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -1,5 +1,6 @@
 use crate::{
     db::{self, log::LogPool, main::conf::schema::Conf, main::user::schema::Role, main::MainPool},
+    service::nip98,
     Result,
 };
 use actix_web::{
@@ -95,6 +96,11 @@ pub enum RpcMethod {
     // Debug
     GetRequestLog,
     GetDailyInfraReport,
+    // Nostr
+    LinkNostrIdentity,
+    UpdateNostrIdentity,
+    RemoveNostrIdentity,
+    CreateApiKeyWithNostr,
 }
 
 impl Role {
@@ -117,9 +123,16 @@ impl Role {
         RpcMethod::GetElementIssues,
         RpcMethod::GetAreaDashboard,
         RpcMethod::GetMostActiveUsers,
+        RpcMethod::CreateApiKeyWithNostr,
     ];
 
-    const USER_METHODS: &[RpcMethod] = &[RpcMethod::Whoami, RpcMethod::GetEvent];
+    const USER_METHODS: &[RpcMethod] = &[
+        RpcMethod::Whoami,
+        RpcMethod::GetEvent,
+        RpcMethod::LinkNostrIdentity,
+        RpcMethod::UpdateNostrIdentity,
+        RpcMethod::RemoveNostrIdentity,
+    ];
 
     const ADMIN_METHODS: &[RpcMethod] = &[
         // Admins can set and override custom place tags
@@ -273,13 +286,14 @@ fn allowed_methods(roles: &[Role]) -> HashSet<RpcMethod> {
 
 #[post("")]
 pub async fn handle(
-    req: HttpRequest,
+    http_req: HttpRequest,
     req_body: String,
     pool: Data<MainPool>,
     conf: Data<Conf>,
     log_pool: Data<LogPool>,
 ) -> Result<Json<RpcResponse>> {
-    let headers = req.headers();
+    let headers = http_req.headers();
+    let req_ref = &http_req;
     let Ok(req) = serde_json::from_str::<Map<String, Value>>(&req_body) else {
         let error_data = json!("Request body is not a valid JSON object");
         return Ok(Json(RpcResponse::error(RpcError::parse_error(Some(
@@ -576,6 +590,38 @@ pub async fn handle(
             req.id.clone(),
             super::log::get_daily_infra_report::run(&log_pool).await?,
         ),
+        // Nostr
+        RpcMethod::LinkNostrIdentity => RpcResponse::from(
+            req.id.clone(),
+            super::nostr::link_nostr_identity::run(params(req.params)?, &user.unwrap(), &pool)
+                .await?,
+        ),
+        RpcMethod::UpdateNostrIdentity => RpcResponse::from(
+            req.id.clone(),
+            super::nostr::update_nostr_identity::run(params(req.params)?, &user.unwrap(), &pool)
+                .await?,
+        ),
+        RpcMethod::RemoveNostrIdentity => RpcResponse::from(
+            req.id.clone(),
+            super::nostr::remove_nostr_identity::run(&user.unwrap(), &pool).await?,
+        ),
+        RpcMethod::CreateApiKeyWithNostr => {
+            let nostr_payload = headers
+                .get(header::AUTHORIZATION)
+                .and_then(|h| h.to_str().ok())
+                .and_then(nip98::extract_nostr_auth)
+                .ok_or("Missing or invalid Authorization: Nostr header")?;
+            let url = format!(
+                "{}://{}{}",
+                req_ref.connection_info().scheme(),
+                req_ref.connection_info().host(),
+                req_ref.uri(),
+            );
+            RpcResponse::from(
+                req.id.clone(),
+                super::nostr::create_api_key_with_nostr::run(nostr_payload, &url, &pool).await?,
+            )
+        }
     }?;
 
     Ok(Json(res))

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -24,6 +24,7 @@ pub mod import;
 pub mod invoice;
 pub mod log;
 pub mod matrix;
+pub mod nostr;
 pub mod paywall_add_element_comment;
 pub mod paywall_boost_element;
 pub mod paywall_get_add_element_comment_quote;

--- a/src/rpc/nostr/create_api_key_with_nostr.rs
+++ b/src/rpc/nostr/create_api_key_with_nostr.rs
@@ -1,0 +1,34 @@
+use crate::db;
+use crate::service::nip98;
+use crate::Result;
+use deadpool_sqlite::Pool;
+use serde::Serialize;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Serialize)]
+pub struct Res {
+    pub token: String,
+    pub time_ms: i128,
+}
+
+pub async fn run(nostr_auth_payload: &str, expected_url: &str, pool: &Pool) -> Result<Res> {
+    let start_time = OffsetDateTime::now_utc();
+
+    let verified = nip98::verify(nostr_auth_payload, expected_url, "POST")
+        .map_err(|e| format!("NIP-98 verification failed: {e}"))?;
+
+    let user = db::main::user::queries::select_by_npub(&verified.pubkey, pool)
+        .await?
+        .ok_or("No BTC Map account linked to this Nostr pubkey")?;
+
+    let token = Uuid::new_v4().to_string();
+    db::main::access_token::queries::insert(user.id, String::new(), token.clone(), vec![], pool)
+        .await?;
+
+    let time_passed_ms = (OffsetDateTime::now_utc() - start_time).whole_milliseconds();
+    Ok(Res {
+        token,
+        time_ms: time_passed_ms,
+    })
+}

--- a/src/rpc/nostr/link_nostr_identity.rs
+++ b/src/rpc/nostr/link_nostr_identity.rs
@@ -1,0 +1,42 @@
+use crate::db;
+use crate::db::main::user::schema::User;
+use crate::service::nip98;
+use crate::Result;
+use deadpool_sqlite::Pool;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct Params {
+    pub nostr_event: String,
+    pub url: String,
+}
+
+#[derive(Serialize)]
+pub struct Res {
+    pub npub: String,
+}
+
+pub async fn run(params: Params, user: &User, pool: &Pool) -> Result<Res> {
+    let verified = nip98::verify(&params.nostr_event, &params.url, "POST")
+        .map_err(|e| format!("NIP-98 verification failed: {e}"))?;
+
+    // Check if user already has a linked Nostr identity
+    if user.npub.is_some() {
+        return Err(
+            "User already has a linked Nostr identity. Use update_nostr_identity to change it."
+                .into(),
+        );
+    }
+
+    // Check if this pubkey is already linked to another account
+    let existing = db::main::user::queries::select_by_npub(&verified.pubkey, pool).await?;
+    if existing.is_some() {
+        return Err("This Nostr pubkey is already linked to another account".into());
+    }
+
+    db::main::user::queries::set_npub(user.id, Some(verified.pubkey.clone()), pool).await?;
+
+    Ok(Res {
+        npub: verified.pubkey,
+    })
+}

--- a/src/rpc/nostr/mod.rs
+++ b/src/rpc/nostr/mod.rs
@@ -1,0 +1,4 @@
+pub mod create_api_key_with_nostr;
+pub mod link_nostr_identity;
+pub mod remove_nostr_identity;
+pub mod update_nostr_identity;

--- a/src/rpc/nostr/remove_nostr_identity.rs
+++ b/src/rpc/nostr/remove_nostr_identity.rs
@@ -1,0 +1,22 @@
+use crate::db;
+use crate::db::main::user::schema::User;
+use crate::Result;
+use deadpool_sqlite::Pool;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct Res {
+    pub message: String,
+}
+
+pub async fn run(user: &User, pool: &Pool) -> Result<Res> {
+    if user.npub.is_none() {
+        return Err("No Nostr identity linked to this account".into());
+    }
+
+    db::main::user::queries::set_npub(user.id, None, pool).await?;
+
+    Ok(Res {
+        message: "Nostr identity removed".into(),
+    })
+}

--- a/src/rpc/nostr/update_nostr_identity.rs
+++ b/src/rpc/nostr/update_nostr_identity.rs
@@ -1,0 +1,43 @@
+use crate::db;
+use crate::db::main::user::schema::User;
+use crate::service::nip98;
+use crate::Result;
+use deadpool_sqlite::Pool;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct Params {
+    pub nostr_event: String,
+    pub url: String,
+}
+
+#[derive(Serialize)]
+pub struct Res {
+    pub npub: String,
+}
+
+pub async fn run(params: Params, user: &User, pool: &Pool) -> Result<Res> {
+    let verified = nip98::verify(&params.nostr_event, &params.url, "POST")
+        .map_err(|e| format!("NIP-98 verification failed: {e}"))?;
+
+    // User must already have a linked Nostr identity to update it
+    if user.npub.is_none() {
+        return Err(
+            "No Nostr identity linked to this account. Use link_nostr_identity first.".into(),
+        );
+    }
+
+    // Check if the new pubkey is already linked to another account
+    let existing = db::main::user::queries::select_by_npub(&verified.pubkey, pool).await?;
+    if let Some(existing_user) = existing {
+        if existing_user.id != user.id {
+            return Err("This Nostr pubkey is already linked to another account".into());
+        }
+    }
+
+    db::main::user::queries::set_npub(user.id, Some(verified.pubkey.clone()), pool).await?;
+
+    Ok(Res {
+        npub: verified.pubkey,
+    })
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -8,6 +8,7 @@ pub mod gitea;
 pub mod invoice;
 pub mod log;
 pub mod matrix;
+pub mod nip98;
 pub mod og;
 pub mod osm;
 pub mod overpass;

--- a/src/service/nip98.rs
+++ b/src/service/nip98.rs
@@ -1,0 +1,225 @@
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use nostr::event::Event;
+use nostr::JsonUtil;
+use nostr::Kind;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const NIP98_KIND: u16 = 27235;
+const MAX_TIMESTAMP_DRIFT_SECS: u64 = 60;
+
+/// Result of a successfully verified NIP-98 event.
+#[derive(Debug)]
+pub struct VerifiedNip98Event {
+    /// Hex-encoded 32-byte Nostr public key.
+    pub pubkey: String,
+}
+
+/// Verify a NIP-98 HTTP auth event.
+///
+/// The `authorization_payload` is the base64-encoded event string
+/// (the part after "Nostr " in the Authorization header).
+///
+/// Validates:
+/// 1. Base64 decoding and JSON parsing
+/// 2. Kind == 27235
+/// 3. created_at within 60 seconds of server time
+/// 4. `u` tag matches expected_url
+/// 5. `method` tag matches expected_method
+/// 6. Schnorr signature is valid
+pub fn verify(
+    authorization_payload: &str,
+    expected_url: &str,
+    expected_method: &str,
+) -> Result<VerifiedNip98Event, String> {
+    // 1. Base64 decode
+    let decoded = BASE64
+        .decode(authorization_payload)
+        .map_err(|e| format!("Invalid base64: {e}"))?;
+
+    let json_str =
+        String::from_utf8(decoded).map_err(|e| format!("Invalid UTF-8 in event: {e}"))?;
+
+    // 2. Parse the Nostr event
+    let event =
+        Event::from_json(&json_str).map_err(|e| format!("Invalid Nostr event JSON: {e}"))?;
+
+    // 3. Verify kind == 27235
+    if event.kind != Kind::from_u16(NIP98_KIND) {
+        return Err(format!(
+            "Invalid event kind: expected {NIP98_KIND}, got {}",
+            event.kind.as_u16()
+        ));
+    }
+
+    // 4. Verify created_at within window
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("System time error: {e}"))?
+        .as_secs();
+    let event_time = event.created_at.as_secs();
+    let drift = now.abs_diff(event_time);
+    if drift > MAX_TIMESTAMP_DRIFT_SECS {
+        return Err(format!(
+            "Event timestamp too far from server time (drift: {drift}s, max: {MAX_TIMESTAMP_DRIFT_SECS}s)"
+        ));
+    }
+
+    // 5. Verify `u` tag matches expected URL
+    let u_tag =
+        find_tag_value(&event, "u").ok_or_else(|| "Missing 'u' tag in NIP-98 event".to_string())?;
+    if u_tag != expected_url {
+        return Err(format!(
+            "URL mismatch: event has '{u_tag}', expected '{expected_url}'"
+        ));
+    }
+
+    // 6. Verify `method` tag matches expected method
+    let method_tag = find_tag_value(&event, "method")
+        .ok_or_else(|| "Missing 'method' tag in NIP-98 event".to_string())?;
+    if !method_tag.eq_ignore_ascii_case(expected_method) {
+        return Err(format!(
+            "Method mismatch: event has '{method_tag}', expected '{expected_method}'"
+        ));
+    }
+
+    // 7. Verify Schnorr signature and event ID
+    event
+        .verify()
+        .map_err(|e| format!("Signature verification failed: {e}"))?;
+
+    Ok(VerifiedNip98Event {
+        pubkey: event.pubkey.to_hex(),
+    })
+}
+
+/// Extract the first value for a given single-letter tag.
+fn find_tag_value(event: &Event, tag_name: &str) -> Option<String> {
+    for tag in event.tags.iter() {
+        let tag_vec = tag.as_slice();
+        if tag_vec.len() >= 2 && tag_vec[0] == tag_name {
+            return Some(tag_vec[1].to_string());
+        }
+    }
+    None
+}
+
+/// Extract the base64 payload from an Authorization header value.
+/// Returns None if the header doesn't use the "Nostr" scheme.
+pub fn extract_nostr_auth(authorization_header: &str) -> Option<&str> {
+    authorization_header.strip_prefix("Nostr ")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use nostr::event::EventBuilder;
+    use nostr::key::Keys;
+    use nostr::Tag;
+    use nostr::Timestamp;
+
+    async fn make_nip98_event(keys: &Keys, url: &str, method: &str) -> String {
+        let event = EventBuilder::new(Kind::from_u16(NIP98_KIND), "")
+            .tags(vec![
+                Tag::parse(["u", url]).unwrap(),
+                Tag::parse(["method", method]).unwrap(),
+            ])
+            .custom_created_at(Timestamp::now())
+            .sign(keys)
+            .await
+            .unwrap();
+        let json = event.as_json();
+        BASE64.encode(json.as_bytes())
+    }
+
+    #[actix_web::test]
+    async fn valid_event() {
+        let keys = Keys::generate();
+        let url = "https://api.btcmap.org/rpc";
+        let method = "POST";
+        let b64 = make_nip98_event(&keys, url, method).await;
+        let result = verify(&b64, url, method);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().pubkey, keys.public_key().to_hex());
+    }
+
+    #[actix_web::test]
+    async fn wrong_url() {
+        let keys = Keys::generate();
+        let b64 = make_nip98_event(&keys, "https://example.com/wrong", "POST").await;
+        let result = verify(&b64, "https://api.btcmap.org/rpc", "POST");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("URL mismatch"));
+    }
+
+    #[actix_web::test]
+    async fn wrong_method() {
+        let keys = Keys::generate();
+        let url = "https://api.btcmap.org/rpc";
+        let b64 = make_nip98_event(&keys, url, "GET").await;
+        let result = verify(&b64, url, "POST");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Method mismatch"));
+    }
+
+    #[actix_web::test]
+    async fn expired_event() {
+        let keys = Keys::generate();
+        let url = "https://api.btcmap.org/rpc";
+        let event = EventBuilder::new(Kind::from_u16(NIP98_KIND), "")
+            .tags(vec![
+                Tag::parse(["u", url]).unwrap(),
+                Tag::parse(["method", "POST"]).unwrap(),
+            ])
+            .custom_created_at(Timestamp::from(0))
+            .sign(&keys)
+            .await
+            .unwrap();
+        let b64 = BASE64.encode(event.as_json().as_bytes());
+        let result = verify(&b64, url, "POST");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("timestamp too far"));
+    }
+
+    #[actix_web::test]
+    async fn wrong_kind() {
+        let keys = Keys::generate();
+        let url = "https://api.btcmap.org/rpc";
+        let event = EventBuilder::new(Kind::from_u16(1), "")
+            .tags(vec![
+                Tag::parse(["u", url]).unwrap(),
+                Tag::parse(["method", "POST"]).unwrap(),
+            ])
+            .custom_created_at(Timestamp::now())
+            .sign(&keys)
+            .await
+            .unwrap();
+        let b64 = BASE64.encode(event.as_json().as_bytes());
+        let result = verify(&b64, url, "POST");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid event kind"));
+    }
+
+    #[test]
+    fn invalid_base64() {
+        let result = verify("not-valid-base64!!!", "https://example.com", "POST");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid base64"));
+    }
+
+    #[test]
+    fn extract_nostr_auth_valid() {
+        let header = "Nostr eyJpZCI6ImZlOTY0ZTc1ODkwMzM2MGYyOGQ4NDI0ZDA5MmRh";
+        let result = extract_nostr_auth(header);
+        assert_eq!(
+            result,
+            Some("eyJpZCI6ImZlOTY0ZTc1ODkwMzM2MGYyOGQ4NDI0ZDA5MmRh")
+        );
+    }
+
+    #[test]
+    fn extract_nostr_auth_bearer() {
+        let result = extract_nostr_auth("Bearer some-token");
+        assert_eq!(result, None);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #82

Introduces NIP-98 HTTP Auth support to associate Nostr pubkeys with BTC Map user accounts and allow passwordless login via Nostr-signed events. NIP-98 is used **only** for identity verification during account linking and token retrieval -- the existing Bearer token system remains the primary auth mechanism for all other API calls.

## Changes

### New dependency
- `nostr` crate v0.44.2 for Schnorr signature verification and Nostr event parsing

### Database
- Migration `99.sql`: adds `UNIQUE` index on `user.npub` (enforces 1:1 Nostr-to-account mapping)

### NIP-98 verification module (`src/service/nip98.rs`)
- Validates base64-encoded kind 27235 events: kind, timestamp (60s window), URL tag, method tag, Schnorr signature
- Shared by both RPC and REST handlers
- 7 unit tests covering valid events, wrong URL/method/kind, expired events, invalid base64

### New RPC methods (4)
| Method | Auth | Purpose |
|--------|------|---------|
| `link_nostr_identity` | Bearer (User+) | Link a Nostr pubkey to the authenticated user |
| `update_nostr_identity` | Bearer (User+) | Replace the linked Nostr pubkey |
| `remove_nostr_identity` | Bearer (User+) | Unlink Nostr from account |
| `create_api_key_with_nostr` | `Authorization: Nostr <base64>` (anonymous) | Get a Bearer token via NIP-98 |

### New REST v4 endpoints (4)
| Endpoint | Method | Auth | Purpose |
|----------|--------|------|---------|
| `/v4/users/me/nostr` | GET | Bearer | Get linked Nostr pubkey |
| `/v4/users/me/nostr` | PUT | Bearer | Link or update Nostr pubkey |
| `/v4/users/me/nostr` | DELETE | Bearer | Remove linked Nostr pubkey |
| `/v4/nostr/token` | POST | `Nostr <base64>` | Get Bearer token via NIP-98 |

### Updated responses
- `GET /v4/users/me` now includes `npub` field
- RPC `whoami` now includes `npub` field

### Documentation
- New `docs/rpc/nostr.md` documenting all 4 RPC methods
- New `docs/rest/v4/nostr.md` documenting POST /v4/nostr/token
- Updated `docs/rest/v4/users.md` with Nostr endpoints and npub field
- Updated `docs/rpc/auth/whoami.md`, `docs/rpc/README.md`, `docs/rpc/public-methods.md`, `docs/rest/v4/README.md`

## User flows

**Link Nostr to existing account:**
1. User logs in normally (password -> Bearer token)
2. User's Nostr client signs a NIP-98 event
3. `PUT /v4/users/me/nostr` or RPC `link_nostr_identity`

**Login with Nostr (passwordless):**
1. User's Nostr client signs a NIP-98 event
2. `POST /v4/nostr/token` with `Authorization: Nostr <base64>`
3. Server returns Bearer token for all subsequent requests

## Test results
- All 313 tests pass
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nostr authentication support for generating API tokens.
  * Added user endpoints to link, update, and remove Nostr identity from accounts.
  * Added RPC methods for Nostr-based authentication and identity management.
  * User profiles now include an optional Nostr public key field.

* **Documentation**
  * Added comprehensive guides for Nostr authentication workflows and identity management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->