### PR TITLE
Change shop water icon

### DIFF
--- a/src/rpc/generate_element_icons.rs
+++ b/src/rpc/generate_element_icons.rs
@@ -774,7 +774,7 @@ impl OverpassElement {
         }
 
         if shop == "water" {
-            icon_id = "sports";
+            icon_id = "water_drop";
         }
 
         if shop == "video" {


### PR DESCRIPTION
Fix shop == water
icon_id = sports (referee whistle icon) into water_drop
Example: Eivavie (https://btcmap.org/merchant/34656)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect icon display for water shop locations—now shows the appropriate water icon instead of the previously incorrect icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->