### PR TITLE
feat(v4): add area-scoped top-editors endpoint

### DIFF
--- a/src/db/main/osm_user/blocking_queries.rs
+++ b/src/db/main/osm_user/blocking_queries.rs
@@ -124,7 +124,7 @@ pub fn select_most_active(
     };
     let sql = format!(
         r#"
-            SELECT 
+            SELECT
                 u.{u_id},
                 json_extract(u.{u_osm_data}, '$.display_name'),
                 json_extract(u.{u_osm_data}, '$.img.href'),
@@ -149,6 +149,66 @@ pub fn select_most_active(
     conn.prepare(&sql)?
         .query_map(
             params![
+                period_start.format(&Rfc3339)?,
+                period_end.format(&Rfc3339)?,
+                limit,
+            ],
+            SelectMostActive::mapper(),
+        )?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+pub fn select_most_active_for_area(
+    area_id: i64,
+    period_start: OffsetDateTime,
+    period_end: OffsetDateTime,
+    limit: i64,
+    excluded_ids: &[i64],
+    conn: &Connection,
+) -> Result<Vec<SelectMostActive>> {
+    let excluded_ids_str: Vec<String> = excluded_ids.iter().map(|id| id.to_string()).collect();
+    let excluded_clause = if excluded_ids.is_empty() {
+        String::new()
+    } else {
+        format!(" AND e.user_id NOT IN ({})", excluded_ids_str.join(","))
+    };
+    let sql = format!(
+        r#"
+            SELECT
+                u.{u_id},
+                json_extract(u.{u_osm_data}, '$.display_name'),
+                json_extract(u.{u_osm_data}, '$.img.href'),
+                json_extract(u.{u_osm_data}, '$.description'),
+                count(*) AS edits,
+                SUM(CASE WHEN e.{type} = 'create' THEN 1 ELSE 0 END) AS created,
+                SUM(CASE WHEN e.{type} = 'update' THEN 1 ELSE 0 END) AS updated,
+                SUM(CASE WHEN e.{type} = 'delete' THEN 1 ELSE 0 END) AS deleted
+            FROM {event_table} e
+            JOIN {table} u ON u.{u_id} = e.user_id
+            JOIN {area_element_table} ae ON ae.{ae_element_id} = e.{e_element_id}
+            WHERE ae.{ae_area_id} = ?1
+              AND ae.{ae_deleted_at} IS NULL
+              AND e.created_at BETWEEN ?2 AND ?3{excluded_clause}
+            GROUP BY e.user_id
+            ORDER BY edits DESC
+            LIMIT ?4
+        "#,
+        u_id = Columns::Id.as_str(),
+        u_osm_data = Columns::OsmData.as_str(),
+        table = schema::NAME,
+        event_table = db::main::element_event::schema::TABLE_NAME,
+        type = db::main::element_event::schema::Columns::Type.as_str(),
+        e_element_id = db::main::element_event::schema::Columns::ElementId.as_str(),
+        area_element_table = db::main::area_element::schema::TABLE_NAME,
+        ae_element_id = db::main::area_element::schema::Columns::ElementId.as_str(),
+        ae_area_id = db::main::area_element::schema::Columns::AreaId.as_str(),
+        ae_deleted_at = db::main::area_element::schema::Columns::DeletedAt.as_str(),
+    );
+    conn.prepare(&sql)?
+        .query_map(
+            params![
+                area_id,
                 period_start.format(&Rfc3339)?,
                 period_end.format(&Rfc3339)?,
                 limit,
@@ -345,6 +405,87 @@ mod test {
         assert_eq!(1, res.len());
         assert_eq!(3, res.first().unwrap().updated);
         assert_eq!(3, res.first().unwrap().edits);
+        Ok(())
+    }
+
+    #[test]
+    fn select_most_active_for_area() -> Result<()> {
+        let conn = conn();
+        let user = super::insert(1, &EditingApiUser::mock(), &conn)?;
+        let other_user = super::insert(2, &EditingApiUser::mock(), &conn)?;
+
+        let element_in_area =
+            db::main::element::blocking_queries::insert(&OverpassElement::mock(1), &conn)?;
+        let element_outside =
+            db::main::element::blocking_queries::insert(&OverpassElement::mock(2), &conn)?;
+
+        let area = db::main::area::blocking_queries::insert(
+            db::main::area::schema::Area::mock_tags(),
+            &conn,
+        )?;
+        db::main::area_element::blocking_queries::insert(area.id, element_in_area.id, &conn)?;
+
+        // Two events on an in-area element by `user` -> should count.
+        db::main::element_event::blocking_queries::insert(
+            user.id,
+            element_in_area.id,
+            "update",
+            &conn,
+        )?;
+        db::main::element_event::blocking_queries::insert(
+            user.id,
+            element_in_area.id,
+            "update",
+            &conn,
+        )?;
+        // One event on an in-area element by `other_user` -> should also count.
+        db::main::element_event::blocking_queries::insert(
+            other_user.id,
+            element_in_area.id,
+            "create",
+            &conn,
+        )?;
+        // One event on an out-of-area element by `user` -> should be excluded.
+        db::main::element_event::blocking_queries::insert(
+            user.id,
+            element_outside.id,
+            "update",
+            &conn,
+        )?;
+
+        let yesterday = OffsetDateTime::now_utc().saturating_add(Duration::days(-1));
+        let tomorrow = OffsetDateTime::now_utc().saturating_add(Duration::days(1));
+
+        let res = super::select_most_active_for_area(area.id, yesterday, tomorrow, 10, &[], &conn)?;
+
+        // Two distinct users have events on in-area elements; user(1) has 2 edits, user(2) has 1.
+        assert_eq!(2, res.len());
+        assert_eq!(user.id, res[0].id);
+        assert_eq!(2, res[0].edits);
+        assert_eq!(other_user.id, res[1].id);
+        assert_eq!(1, res[1].edits);
+
+        // The out-of-area event must not have been counted.
+        assert_eq!(2, res[0].updated);
+        assert_eq!(0, res[0].created);
+
+        // exclude `user` and confirm only `other_user` remains.
+        let res = super::select_most_active_for_area(
+            area.id,
+            yesterday,
+            tomorrow,
+            10,
+            &[user.id],
+            &conn,
+        )?;
+        assert_eq!(1, res.len());
+        assert_eq!(other_user.id, res[0].id);
+
+        // Non-existent area id returns no rows.
+        let res =
+            super::select_most_active_for_area(area.id + 999, yesterday, tomorrow, 10, &[], &conn)?;
+        assert_eq!(0, res.len());
+
         Ok(())
     }
 

--- a/src/db/main/osm_user/blocking_queries.rs
+++ b/src/db/main/osm_user/blocking_queries.rs
@@ -5,6 +5,7 @@ use crate::{
     service::osm::EditingApiUser,
     Result,
 };
+use rusqlite::types::ToSql;
 use rusqlite::{params, Connection, Row};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -116,11 +117,24 @@ pub fn select_most_active(
     excluded_ids: &[i64],
     conn: &Connection,
 ) -> Result<Vec<SelectMostActive>> {
-    let excluded_ids_str: Vec<String> = excluded_ids.iter().map(|id| id.to_string()).collect();
+    let mut sql_params: Vec<Box<dyn ToSql>> = vec![
+        Box::new(period_start.format(&Rfc3339)?),
+        Box::new(period_end.format(&Rfc3339)?),
+        Box::new(limit),
+    ];
     let excluded_clause = if excluded_ids.is_empty() {
         String::new()
     } else {
-        format!(" AND e.user_id NOT IN ({})", excluded_ids_str.join(","))
+        let start = sql_params.len() + 1;
+        let placeholders: Vec<String> = excluded_ids
+            .iter()
+            .enumerate()
+            .map(|(i, &id)| {
+                sql_params.push(Box::new(id));
+                format!("?{}", start + i)
+            })
+            .collect();
+        format!(" AND e.user_id NOT IN ({})", placeholders.join(", "))
     };
     let sql = format!(
         r#"
@@ -146,15 +160,9 @@ pub fn select_most_active(
         event_table = db::main::element_event::schema::TABLE_NAME,
         type = db::main::element_event::schema::Columns::Type.as_str(),
     );
+    let refs: Vec<&dyn ToSql> = sql_params.iter().map(|p| p.as_ref()).collect();
     conn.prepare(&sql)?
-        .query_map(
-            params![
-                period_start.format(&Rfc3339)?,
-                period_end.format(&Rfc3339)?,
-                limit,
-            ],
-            SelectMostActive::mapper(),
-        )?
+        .query_map(refs.as_slice(), SelectMostActive::mapper())?
         .collect::<Result<Vec<_>, _>>()
         .map_err(Into::into)
 }
@@ -167,11 +175,25 @@ pub fn select_most_active_for_area(
     excluded_ids: &[i64],
     conn: &Connection,
 ) -> Result<Vec<SelectMostActive>> {
-    let excluded_ids_str: Vec<String> = excluded_ids.iter().map(|id| id.to_string()).collect();
+    let mut sql_params: Vec<Box<dyn ToSql>> = vec![
+        Box::new(area_id),
+        Box::new(period_start.format(&Rfc3339)?),
+        Box::new(period_end.format(&Rfc3339)?),
+        Box::new(limit),
+    ];
     let excluded_clause = if excluded_ids.is_empty() {
         String::new()
     } else {
-        format!(" AND e.user_id NOT IN ({})", excluded_ids_str.join(","))
+        let start = sql_params.len() + 1;
+        let placeholders: Vec<String> = excluded_ids
+            .iter()
+            .enumerate()
+            .map(|(i, &id)| {
+                sql_params.push(Box::new(id));
+                format!("?{}", start + i)
+            })
+            .collect();
+        format!(" AND e.user_id NOT IN ({})", placeholders.join(", "))
     };
     let sql = format!(
         r#"
@@ -205,16 +227,9 @@ pub fn select_most_active_for_area(
         ae_area_id = db::main::area_element::schema::Columns::AreaId.as_str(),
         ae_deleted_at = db::main::area_element::schema::Columns::DeletedAt.as_str(),
     );
+    let refs: Vec<&dyn ToSql> = sql_params.iter().map(|p| p.as_ref()).collect();
     conn.prepare(&sql)?
-        .query_map(
-            params![
-                area_id,
-                period_start.format(&Rfc3339)?,
-                period_end.format(&Rfc3339)?,
-                limit,
-            ],
-            SelectMostActive::mapper(),
-        )?
+        .query_map(refs.as_slice(), SelectMostActive::mapper())?
         .collect::<Result<Vec<_>, _>>()
         .map_err(Into::into)
 }

--- a/src/db/main/osm_user/queries.rs
+++ b/src/db/main/osm_user/queries.rs
@@ -41,6 +41,30 @@ pub async fn select_most_active(
         .await?
 }
 
+pub async fn select_most_active_for_area(
+    area_id: i64,
+    period_start: OffsetDateTime,
+    period_end: OffsetDateTime,
+    limit: i64,
+    excluded_ids: &[i64],
+    pool: &Pool,
+) -> Result<Vec<SelectMostActive>> {
+    let excluded_ids = excluded_ids.to_vec();
+    pool.get()
+        .await?
+        .interact(move |conn| {
+            super::blocking_queries::select_most_active_for_area(
+                area_id,
+                period_start,
+                period_end,
+                limit,
+                &excluded_ids,
+                conn,
+            )
+        })
+        .await?
+}
+
 pub async fn select_all(limit: Option<i64>, pool: &Pool) -> Result<Vec<OsmUser>> {
     pool.get()
         .await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,7 @@ async fn main() -> Result<()> {
                         scope("areas")
                             .service(rest::v4::areas::get_saved)
                             .service(rest::v4::areas::put_saved)
+                            .service(rest::v4::areas::get_by_id_top_editors)
                             .service(rest::v4::areas::get)
                             .service(rest::v4::areas::get_by_id),
                     )

--- a/src/rest/v4/areas.rs
+++ b/src/rest/v4/areas.rs
@@ -3,12 +3,13 @@ use crate::db::main::MainPool;
 use crate::rest::auth::Auth;
 use crate::rest::error::RestResult as Res;
 use crate::rest::error::{RestApiError, RestApiErrorCode};
-use crate::rest::v4::top_editors::{extract_tip_url, parse_date, TopEditor, EXCLUDED_USER_IDS};
+use crate::rest::v4::top_editors::{
+    extract_tip_url, far_future, parse_date, validate_limit, TopEditor, EXCLUDED_USER_IDS,
+};
 use crate::service;
 use crate::Error;
 use actix_web::{get, put, web::Data, web::Json, web::Path, web::Query};
 use serde::{Deserialize, Serialize};
-use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 #[derive(Deserialize)]
@@ -108,6 +109,9 @@ pub struct GetByIdRes {
 
 #[get("{id}")]
 pub async fn get_by_id(id: Path<String>, pool: Data<MainPool>) -> Res<GetByIdRes> {
+    if id.len() > 128 {
+        return Err(RestApiError::invalid_input("id too long"));
+    }
     let area = db::main::area::queries::select_by_id_or_alias(id.into_inner(), &pool)
         .await
         .map_err(|e| match e {
@@ -205,6 +209,9 @@ pub async fn get_by_id_top_editors(
     args: Query<GetTopEditorsForAreaArgs>,
     pool: Data<MainPool>,
 ) -> Res<Vec<TopEditor>> {
+    if id.len() > 128 {
+        return Err(RestApiError::invalid_input("id too long"));
+    }
     let area = db::main::area::queries::select_by_id_or_alias(id.into_inner(), &pool)
         .await
         .map_err(|e| match e {
@@ -220,14 +227,13 @@ pub async fn get_by_id_top_editors(
         Some(s) => parse_date(s, false)?,
         None => far_future(),
     };
-    let limit = args.limit.unwrap_or(100).clamp(1, 1000);
-    let query_limit = limit.saturating_add(EXCLUDED_USER_IDS.len() as i64);
+    let limit = validate_limit(args.limit)?;
 
     let editors = db::main::osm_user::queries::select_most_active_for_area(
         area.id,
         period_start,
         period_end,
-        query_limit,
+        limit,
         EXCLUDED_USER_IDS,
         &pool,
     )
@@ -246,15 +252,9 @@ pub async fn get_by_id_top_editors(
             places_deleted: e.deleted,
             tip_url: extract_tip_url(&e.description),
         })
-        .take(limit as usize)
         .collect();
 
     Ok(Json(editors))
-}
-
-fn far_future() -> OffsetDateTime {
-    OffsetDateTime::parse("2200-01-01T00:00:00Z", &Rfc3339)
-        .expect("constant date literal must parse")
 }
 
 #[cfg(test)]

--- a/src/rest/v4/areas.rs
+++ b/src/rest/v4/areas.rs
@@ -3,7 +3,7 @@ use crate::db::main::MainPool;
 use crate::rest::auth::Auth;
 use crate::rest::error::RestResult as Res;
 use crate::rest::error::{RestApiError, RestApiErrorCode};
-use crate::rest::v4::top_editors::{extract_tip_url, TopEditor, EXCLUDED_USER_IDS};
+use crate::rest::v4::top_editors::{extract_tip_url, parse_date, TopEditor, EXCLUDED_USER_IDS};
 use crate::service;
 use crate::Error;
 use actix_web::{get, put, web::Data, web::Json, web::Path, web::Query};
@@ -220,8 +220,8 @@ pub async fn get_by_id_top_editors(
         Some(s) => parse_date(s, false)?,
         None => far_future(),
     };
-    let limit = args.limit.unwrap_or(100);
-    let query_limit = limit + EXCLUDED_USER_IDS.len() as i64;
+    let limit = args.limit.unwrap_or(100).clamp(1, 1000);
+    let query_limit = limit.saturating_add(EXCLUDED_USER_IDS.len() as i64);
 
     let editors = db::main::osm_user::queries::select_most_active_for_area(
         area.id,
@@ -252,23 +252,9 @@ pub async fn get_by_id_top_editors(
     Ok(Json(editors))
 }
 
-fn parse_date(date_str: &str, is_start: bool) -> Result<OffsetDateTime, RestApiError> {
-    let formatted = if is_start {
-        format!("{}T00:00:00Z", date_str)
-    } else {
-        let next_day = OffsetDateTime::parse(&format!("{}T00:00:00Z", date_str), &Rfc3339)
-            .map_err(|_| RestApiError::invalid_input("Invalid date format"))?
-            .saturating_add(time::Duration::days(1));
-        format!("{}T00:00:00Z", next_day.date())
-    };
-    OffsetDateTime::parse(&formatted, &Rfc3339)
-        .map_err(|_| RestApiError::invalid_input("Invalid date format"))
-}
-
 fn far_future() -> OffsetDateTime {
-    // Sentinel upper bound used when the caller doesn't specify period_end.
-    // Any year well past today's date works; 2200-01-01 leaves plenty of headroom.
-    OffsetDateTime::parse("2200-01-01T00:00:00Z", &Rfc3339).unwrap_or(OffsetDateTime::UNIX_EPOCH)
+    OffsetDateTime::parse("2200-01-01T00:00:00Z", &Rfc3339)
+        .expect("constant date literal must parse")
 }
 
 #[cfg(test)]

--- a/src/rest/v4/areas.rs
+++ b/src/rest/v4/areas.rs
@@ -3,10 +3,13 @@ use crate::db::main::MainPool;
 use crate::rest::auth::Auth;
 use crate::rest::error::RestResult as Res;
 use crate::rest::error::{RestApiError, RestApiErrorCode};
+use crate::rest::v4::top_editors::{extract_tip_url, TopEditor, EXCLUDED_USER_IDS};
 use crate::service;
 use crate::Error;
 use actix_web::{get, put, web::Data, web::Json, web::Path, web::Query};
 use serde::{Deserialize, Serialize};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 #[derive(Deserialize)]
 pub struct SearchArgs {
@@ -185,6 +188,89 @@ pub async fn put_saved(auth: Auth, args: Json<Vec<i64>>, pool: Data<MainPool>) -
     Ok(actix_web::web::Json(args.into_inner()))
 }
 
+#[derive(Deserialize)]
+pub struct GetTopEditorsForAreaArgs {
+    period_start: Option<String>,
+    period_end: Option<String>,
+    limit: Option<i64>,
+}
+
+/// Return the most active editors whose changes fell on places inside the given
+/// area. Mirrors the global `/v4/top-editors` response shape and bot-id
+/// blocklist; the only difference is the area scope and the date-range params
+/// being optional (default to an open range).
+#[get("{id}/top-editors")]
+pub async fn get_by_id_top_editors(
+    id: Path<String>,
+    args: Query<GetTopEditorsForAreaArgs>,
+    pool: Data<MainPool>,
+) -> Res<Vec<TopEditor>> {
+    let area = db::main::area::queries::select_by_id_or_alias(id.into_inner(), &pool)
+        .await
+        .map_err(|e| match e {
+            Error::Rusqlite(rusqlite::Error::QueryReturnedNoRows) => RestApiError::not_found(),
+            _ => RestApiError::database(),
+        })?;
+
+    let period_start = match args.period_start.as_deref() {
+        Some(s) => parse_date(s, true)?,
+        None => OffsetDateTime::UNIX_EPOCH,
+    };
+    let period_end = match args.period_end.as_deref() {
+        Some(s) => parse_date(s, false)?,
+        None => far_future(),
+    };
+    let limit = args.limit.unwrap_or(100);
+    let query_limit = limit + EXCLUDED_USER_IDS.len() as i64;
+
+    let editors = db::main::osm_user::queries::select_most_active_for_area(
+        area.id,
+        period_start,
+        period_end,
+        query_limit,
+        EXCLUDED_USER_IDS,
+        &pool,
+    )
+    .await
+    .map_err(|_| RestApiError::database())?;
+
+    let editors: Vec<TopEditor> = editors
+        .into_iter()
+        .map(|e| TopEditor {
+            id: e.id,
+            name: e.name,
+            avatar_url: e.image_url,
+            total_edits: e.edits,
+            places_created: e.created,
+            places_updated: e.updated,
+            places_deleted: e.deleted,
+            tip_url: extract_tip_url(&e.description),
+        })
+        .take(limit as usize)
+        .collect();
+
+    Ok(Json(editors))
+}
+
+fn parse_date(date_str: &str, is_start: bool) -> Result<OffsetDateTime, RestApiError> {
+    let formatted = if is_start {
+        format!("{}T00:00:00Z", date_str)
+    } else {
+        let next_day = OffsetDateTime::parse(&format!("{}T00:00:00Z", date_str), &Rfc3339)
+            .map_err(|_| RestApiError::invalid_input("Invalid date format"))?
+            .saturating_add(time::Duration::days(1));
+        format!("{}T00:00:00Z", next_day.date())
+    };
+    OffsetDateTime::parse(&formatted, &Rfc3339)
+        .map_err(|_| RestApiError::invalid_input("Invalid date format"))
+}
+
+fn far_future() -> OffsetDateTime {
+    // Sentinel upper bound used when the caller doesn't specify period_end.
+    // Any year well past today's date works; 2200-01-01 leaves plenty of headroom.
+    OffsetDateTime::parse("2200-01-01T00:00:00Z", &Rfc3339).unwrap_or(OffsetDateTime::UNIX_EPOCH)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -323,6 +409,108 @@ mod test {
         let res: GetByIdRes = test::call_and_read_body_json(&app, req).await;
         assert_eq!(res.name, "Phuket");
         assert_eq!(res.description, "A beautiful island in Thailand");
+        Ok(())
+    }
+
+    #[test]
+    async fn top_editors_for_unknown_area_returns_404() -> Result<()> {
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool()))
+                .service(super::get_by_id_top_editors),
+        )
+        .await;
+        let req = TestRequest::get().uri("/9999/top-editors").to_request();
+        let res = test::call_service(&app, req).await;
+        assert_eq!(res.status(), 404);
+        Ok(())
+    }
+
+    #[test]
+    async fn top_editors_for_area_scopes_to_area_elements() -> Result<()> {
+        use crate::service::osm::EditingApiUser;
+        use crate::service::overpass::OverpassElement;
+
+        let pool = pool();
+        let area = db::main::area::queries::insert(Area::mock_tags(), &pool).await?;
+        let user = db::main::osm_user::queries::insert(1, EditingApiUser::mock(), &pool).await?;
+        let other_user =
+            db::main::osm_user::queries::insert(2, EditingApiUser::mock(), &pool).await?;
+
+        let element_in_area =
+            db::main::element::queries::insert(OverpassElement::mock(1), &pool).await?;
+        let element_outside =
+            db::main::element::queries::insert(OverpassElement::mock(2), &pool).await?;
+
+        db::main::area_element::queries::insert(area.id, element_in_area.id, &pool).await?;
+
+        // 2 in-area edits by `user`
+        db::main::element_event::queries::insert(user.id, element_in_area.id, "update", &pool)
+            .await?;
+        db::main::element_event::queries::insert(user.id, element_in_area.id, "update", &pool)
+            .await?;
+        // 1 in-area edit by `other_user`
+        db::main::element_event::queries::insert(
+            other_user.id,
+            element_in_area.id,
+            "create",
+            &pool,
+        )
+        .await?;
+        // 1 out-of-area edit by `user` — must be excluded.
+        db::main::element_event::queries::insert(user.id, element_outside.id, "update", &pool)
+            .await?;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool))
+                .service(super::get_by_id_top_editors),
+        )
+        .await;
+
+        let req = TestRequest::get()
+            .uri(&format!("/{}/top-editors", area.id))
+            .to_request();
+        let res: Vec<TopEditor> = test::call_and_read_body_json(&app, req).await;
+
+        assert_eq!(2, res.len());
+        // user (id=1) leads with 2 in-area edits; other_user with 1.
+        assert_eq!(user.id, res[0].id);
+        assert_eq!(2, res[0].total_edits);
+        assert_eq!(2, res[0].places_updated);
+        assert_eq!(0, res[0].places_created);
+        assert_eq!(other_user.id, res[1].id);
+        assert_eq!(1, res[1].total_edits);
+        assert_eq!(1, res[1].places_created);
+        Ok(())
+    }
+
+    #[test]
+    async fn top_editors_for_area_respects_limit() -> Result<()> {
+        use crate::service::osm::EditingApiUser;
+        use crate::service::overpass::OverpassElement;
+
+        let pool = pool();
+        let area = db::main::area::queries::insert(Area::mock_tags(), &pool).await?;
+        let element = db::main::element::queries::insert(OverpassElement::mock(1), &pool).await?;
+        db::main::area_element::queries::insert(area.id, element.id, &pool).await?;
+
+        for uid in 1..=3 {
+            let u = db::main::osm_user::queries::insert(uid, EditingApiUser::mock(), &pool).await?;
+            db::main::element_event::queries::insert(u.id, element.id, "update", &pool).await?;
+        }
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool))
+                .service(super::get_by_id_top_editors),
+        )
+        .await;
+        let req = TestRequest::get()
+            .uri(&format!("/{}/top-editors?limit=2", area.id))
+            .to_request();
+        let res: Vec<TopEditor> = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(2, res.len());
         Ok(())
     }
 }

--- a/src/rest/v4/top_editors.rs
+++ b/src/rest/v4/top_editors.rs
@@ -30,22 +30,26 @@ pub struct TopEditor {
     pub tip_url: Option<String>,
 }
 
+/// Spam/bot user ids excluded from "top editors" rankings. Shared with the
+/// area-scoped top-editors endpoint in `super::areas` so the two views can't
+/// drift apart.
+pub(crate) const EXCLUDED_USER_IDS: &[i64] = &[
+    9451067, 18545877, 19880430, 242345, 232801, 1778799, 21749653,
+];
+
 #[get("")]
 pub async fn get(args: Query<GetTopEditorsArgs>, pool: Data<MainPool>) -> Res<Vec<TopEditor>> {
     let period_start = parse_date(&args.period_start, true)?;
     let period_end = parse_date(&args.period_end, false)?;
     let limit = args.limit.unwrap_or(100);
 
-    let excluded_ids = [
-        9451067, 18545877, 19880430, 242345, 232801, 1778799, 21749653,
-    ];
-    let query_limit = limit + excluded_ids.len() as i64;
+    let query_limit = limit + EXCLUDED_USER_IDS.len() as i64;
 
     let editors = crate::db::main::osm_user::queries::select_most_active(
         period_start,
         period_end,
         query_limit,
-        &excluded_ids,
+        EXCLUDED_USER_IDS,
         &pool,
     )
     .await
@@ -83,7 +87,7 @@ fn parse_date(date_str: &str, is_start: bool) -> Result<OffsetDateTime, RestApiE
         .map_err(|_| RestApiError::invalid_input("Invalid date format"))
 }
 
-fn extract_tip_url(description: &str) -> Option<String> {
+pub(crate) fn extract_tip_url(description: &str) -> Option<String> {
     let re = Regex::new(r"(lightning:[^)]+)").ok()?;
     re.captures(description).map(|c| c[1].to_string())
 }

--- a/src/rest/v4/top_editors.rs
+++ b/src/rest/v4/top_editors.rs
@@ -8,6 +8,7 @@ use actix_web::web::Query;
 use regex::Regex;
 use serde::Deserialize;
 use serde::Serialize;
+use std::sync::OnceLock;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
@@ -41,9 +42,9 @@ pub(crate) const EXCLUDED_USER_IDS: &[i64] = &[
 pub async fn get(args: Query<GetTopEditorsArgs>, pool: Data<MainPool>) -> Res<Vec<TopEditor>> {
     let period_start = parse_date(&args.period_start, true)?;
     let period_end = parse_date(&args.period_end, false)?;
-    let limit = args.limit.unwrap_or(100);
+    let limit = args.limit.unwrap_or(100).clamp(1, 1000);
 
-    let query_limit = limit + EXCLUDED_USER_IDS.len() as i64;
+    let query_limit = limit.saturating_add(EXCLUDED_USER_IDS.len() as i64);
 
     let editors = crate::db::main::osm_user::queries::select_most_active(
         period_start,
@@ -73,7 +74,7 @@ pub async fn get(args: Query<GetTopEditorsArgs>, pool: Data<MainPool>) -> Res<Ve
     Ok(Json(editors))
 }
 
-fn parse_date(date_str: &str, is_start: bool) -> Result<OffsetDateTime, RestApiError> {
+pub(crate) fn parse_date(date_str: &str, is_start: bool) -> Result<OffsetDateTime, RestApiError> {
     let date_str = if is_start {
         format!("{}T00:00:00Z", date_str)
     } else {
@@ -87,8 +88,10 @@ fn parse_date(date_str: &str, is_start: bool) -> Result<OffsetDateTime, RestApiE
         .map_err(|_| RestApiError::invalid_input("Invalid date format"))
 }
 
+static TIP_URL_RE: OnceLock<Regex> = OnceLock::new();
+
 pub(crate) fn extract_tip_url(description: &str) -> Option<String> {
-    let re = Regex::new(r"(lightning:[^)]+)").ok()?;
+    let re = TIP_URL_RE.get_or_init(|| Regex::new(r"(lightning:[^)]+)").unwrap());
     re.captures(description).map(|c| c[1].to_string())
 }
 

--- a/src/rest/v4/top_editors.rs
+++ b/src/rest/v4/top_editors.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::sync::OnceLock;
 use time::format_description::well_known::Rfc3339;
+use time::macros::datetime;
 use time::OffsetDateTime;
 
 #[derive(Deserialize)]
@@ -42,14 +43,12 @@ pub(crate) const EXCLUDED_USER_IDS: &[i64] = &[
 pub async fn get(args: Query<GetTopEditorsArgs>, pool: Data<MainPool>) -> Res<Vec<TopEditor>> {
     let period_start = parse_date(&args.period_start, true)?;
     let period_end = parse_date(&args.period_end, false)?;
-    let limit = args.limit.unwrap_or(100).clamp(1, 1000);
-
-    let query_limit = limit.saturating_add(EXCLUDED_USER_IDS.len() as i64);
+    let limit = validate_limit(args.limit)?;
 
     let editors = crate::db::main::osm_user::queries::select_most_active(
         period_start,
         period_end,
-        query_limit,
+        limit,
         EXCLUDED_USER_IDS,
         &pool,
     )
@@ -68,7 +67,6 @@ pub async fn get(args: Query<GetTopEditorsArgs>, pool: Data<MainPool>) -> Res<Ve
             places_deleted: e.deleted,
             tip_url: extract_tip_url(&e.description),
         })
-        .take(limit as usize)
         .collect();
 
     Ok(Json(editors))
@@ -86,6 +84,20 @@ pub(crate) fn parse_date(date_str: &str, is_start: bool) -> Result<OffsetDateTim
 
     OffsetDateTime::parse(&date_str, &Rfc3339)
         .map_err(|_| RestApiError::invalid_input("Invalid date format"))
+}
+
+pub(crate) fn validate_limit(limit: Option<i64>) -> Result<i64, RestApiError> {
+    let limit = limit.unwrap_or(100);
+    if !(1..=1000).contains(&limit) {
+        return Err(RestApiError::invalid_input(
+            "limit must be between 1 and 1000",
+        ));
+    }
+    Ok(limit)
+}
+
+pub(crate) fn far_future() -> OffsetDateTime {
+    datetime!(2200-01-01 0:00 UTC)
 }
 
 static TIP_URL_RE: OnceLock<Regex> = OnceLock::new();


### PR DESCRIPTION
Related to: https://github.com/teambtcmap/btcmap.org/pull/927

## Desc

GET /v4/areas/{id}/top-editors?period_start=&period_end=&limit=

Returns the same TopEditor shape as GET /v4/top-editors, but counts only events whose target element belongs to the given area (joined through area_element). The {id} segment accepts either the numeric area id or the string alias (handled by select_by_id_or_alias, same as v3).

Why: the btcmap.org Activity tab on country/community pages currently derives its "Supertaggers" list client-side by fetching osm_id for every place in the area (one /v4/places/{id} per place — ~7940 requests per visit on the US page) and matching against the global events feed. With this endpoint the FE can replace all that with a single REST call.

Notes for the maintainer:
- period_start / period_end are optional here (default to an open range via UNIX_EPOCH .. 2200-01-01). The FE has no period filter in its current Supertaggers UI; nothing prevents callers from supplying bounds though, and the format/parsing matches /v4/top-editors.
- The bot/spam blocklist (EXCLUDED_USER_IDS) is now declared once in top_editors.rs and shared, so the two views can't drift apart.
- area_element rows with deleted_at IS NOT NULL are excluded from the join — matches the convention in get_by_id_areas.

Tests:
- select_most_active_for_area unit test covers area scoping (out-of-area events excluded), excluded_ids filter, and unknown-area returning 0.
- Three handler tests cover unknown-area 404, end-to-end scoping, and the limit query param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new `/top-editors` API endpoint to view the most active editors within a specific area, with optional date range filtering and configurable result limits.

* **Improvements**
  * Added validation for API parameters, including area ID length checks and editor count limits (1–1000 range).
  * Enhanced performance through optimization of spam/bot filtering mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->