### PR TITLE
feat: activity places filter

### DIFF
--- a/docs/rest/v4/README.md
+++ b/docs/rest/v4/README.md
@@ -9,6 +9,7 @@ The latest and recommended version of the BTCMap API, offering improved performa
 - **[Place Boosts](place-boosts.md)** - Fetch place boost quotes and submit boost intents.
 - **[Place Comments](place-comments.md)** - Fetch place comment quotes and submit comment intents.
 - **[Events](events.md)** - Fetch events.
+- **[Activity](activity.md)** - Fetch a merged feed of place activity, optionally scoped to areas and/or places.
 - **[Invoices](invoices.md)** - Check invoice status for boosts, comments and other paywalled features.
 - **[Users](users.md)** - Get authenticated user information.  
 ### Planned

--- a/docs/rest/v4/activity.md
+++ b/docs/rest/v4/activity.md
@@ -1,0 +1,86 @@
+# Activity REST API (v4)
+
+This document describes the endpoint for fetching a merged feed of
+place-related activity in REST API v4.
+
+## Available Endpoints
+
+- [Get Activity Feed](#get-activity-feed)
+
+### Get Activity Feed
+
+```bash
+curl --request GET https://api.btcmap.org/v4/activity
+```
+
+Returns a merged, time-sorted feed of recent place activity — creates,
+updates, deletes, comments, and paid boosts — sorted newest-first. The
+response is a flat array; each item carries a `type` discriminating the
+kind of activity. Results can be scoped to one or more areas, one or
+more places, or the combination of both.
+
+This endpoint is **public** — no authentication header is required.
+
+#### Parameters
+
+| Parameter | Type | Example | Default | Description |
+|-----------|------|---------|---------|-------------|
+| `days` | Integer | `7` | `1` | Lookback window in days. Must be `1 <= days <= 3650`. |
+| `area` | String (ID or alias) | `germany` | - | Scope to a single area. Accepts the numeric area ID or the `url_alias`. Ignored when `areas` is provided. |
+| `areas` | Comma-separated list of IDs / aliases | `germany,berlin` | - | Scope to multiple areas. Takes precedence over `area`. |
+| `places` | Comma-separated list of integer place IDs | `38625,23143` | - | Scope to explicit places. Accepts at most 500 comma-separated values. |
+
+When both `areas` and `places` are provided, the element set is the
+**union** of elements belonging to any of the areas plus the explicit
+place IDs. Duplicates are removed server-side, so saving a country
+*and* a specific place inside that country will not produce duplicate
+activity items.
+
+#### Response Shape
+
+```jsonc
+[
+  {
+    "type": "place_added",          // place_added | place_updated | place_deleted | place_commented | place_boosted
+    "place_id": 38625,
+    "place_name": "Example Cafe",   // optional
+    "osm_user_id": 12345,           // optional; present for place_added / place_updated / place_deleted
+    "osm_user_name": "alice",       // optional; matches osm_user_id
+    "osm_user_tip": "lightning:…",  // optional; parsed from the OSM user's description
+    "comment": "great spot",        // optional; present for place_commented
+    "duration_days": 30,            // optional; present for place_boosted
+    "image": "https://api.btcmap.org/og/element/38625",
+    "date": "2026-04-20T12:00:00Z"
+  }
+]
+```
+
+#### Examples
+
+##### Global activity, last 24 hours
+
+```bash
+curl --request GET https://api.btcmap.org/v4/activity | jq
+```
+
+##### All activity in Germany over the last week
+
+```bash
+curl --request GET "https://api.btcmap.org/v4/activity?area=germany&days=7" | jq
+```
+
+##### Activity for a user's saved places and saved areas
+
+```bash
+curl --request GET \
+  "https://api.btcmap.org/v4/activity?areas=1,2&places=38625,23143&days=30" | jq
+```
+
+#### Error Cases
+
+| HTTP status | `code` | Condition |
+|-------------|--------|-----------|
+| 400 | `invalid_input` | `days` outside `[1, 3650]`. |
+| 400 | `invalid_input` | `places` contains a non-integer value. |
+| 400 | `invalid_input` | `places` contains more than 500 comma-separated values. |
+| 404 | `not_found` | An ID or alias in `area` / `areas` does not resolve to an area. |

--- a/src/rest/v4/activity.rs
+++ b/src/rest/v4/activity.rs
@@ -30,6 +30,7 @@ pub struct GetActivityArgs {
     days: Option<i64>,
     area: Option<String>,
     areas: Option<String>,
+    places: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -104,9 +105,17 @@ pub async fn get(
         }
     }
 
+    let places: Vec<i64> = match &args.places {
+        Some(comma_separated_places) => comma_separated_places
+            .split(",")
+            .filter_map(|s| s.trim().parse::<i64>().ok())
+            .collect(),
+        None => Vec::new(),
+    };
+
     let mut elements: Option<HashSet<i64>> = None;
 
-    if !areas.is_empty() {
+    if !areas.is_empty() || !places.is_empty() {
         let mut combined_elements: HashSet<i64> = HashSet::new();
         for area in &areas {
             let area_elements = db::main::area_element::queries::select_by_area_id(*area, &pool)
@@ -118,18 +127,21 @@ pub async fn get(
                 }
             }
         }
+        for place_id in &places {
+            combined_elements.insert(*place_id);
+        }
         elements = Some(combined_elements);
     }
 
-    let in_area = |element_id: i64| -> bool {
+    let in_filter = |element_id: i64| -> bool {
         match &elements {
             Some(ids) => ids.contains(&element_id),
             None => true,
         }
     };
 
-    // Fetch events — areas-scoped or global
-    let events = if !areas.is_empty() {
+    // Fetch events — area-scoped (optimized), global, or global + post-filter
+    let events = if !areas.is_empty() && places.is_empty() {
         let mut combined: HashSet<ElementEvent> = HashSet::new();
         for area in &areas {
             let area_events = db::main::element_event::queries::select_created_between_for_area(
@@ -150,6 +162,9 @@ pub async fn get(
 
     let mut items: Vec<ActivityItem> = Vec::with_capacity(events.len());
     for event in events {
+        if !in_filter(event.element_id) {
+            continue;
+        }
         let element = db::main::element::queries::select_by_id(event.element_id, &pool)
             .await
             .map_err(|_| RestApiError::database())?;
@@ -178,8 +193,8 @@ pub async fn get(
         });
     }
 
-    // Fetch comments — areas-scoped or global
-    let comments = if !areas.is_empty() {
+    // Fetch comments — area-scoped (optimized), global, or global + post-filter
+    let comments = if !areas.is_empty() && places.is_empty() {
         let mut combined: HashSet<ElementComment> = HashSet::new();
         for area in areas {
             let comments = db::main::element_comment::queries::select_created_between_for_area(
@@ -200,6 +215,9 @@ pub async fn get(
 
     for comment in comments {
         if comment.deleted_at.is_some() {
+            continue;
+        }
+        if !in_filter(comment.element_id) {
             continue;
         }
 
@@ -239,7 +257,7 @@ pub async fn get(
             continue;
         };
 
-        if !in_area(element_id) {
+        if !in_filter(element_id) {
             continue;
         }
 
@@ -287,6 +305,7 @@ mod test {
     use actix_web::test::TestRequest;
     use actix_web::web::{scope, Data};
     use actix_web::{test, App};
+    use std::collections::HashSet;
 
     #[test]
     async fn get_empty_array() -> Result<()> {
@@ -590,6 +609,134 @@ mod test {
         assert_eq!(1, res.len());
         assert_eq!(super::EVENT_TYPE_BOOST, res[0].r#type);
         assert_eq!(element_in_area.id, res[0].place_id);
+        Ok(())
+    }
+
+    #[test]
+    async fn get_filtered_by_places() -> Result<()> {
+        let pool = pool();
+        let user = db::main::osm_user::queries::insert(
+            1,
+            crate::service::osm::EditingApiUser::mock(),
+            &pool,
+        )
+        .await?;
+
+        let place_a = db::main::element::queries::insert(OverpassElement::mock(1), &pool).await?;
+        let place_b = db::main::element::queries::insert(OverpassElement::mock(2), &pool).await?;
+        let place_c = db::main::element::queries::insert(OverpassElement::mock(3), &pool).await?;
+
+        db::main::element_event::queries::insert(user.id, place_a.id, "create", &pool).await?;
+        db::main::element_event::queries::insert(user.id, place_b.id, "create", &pool).await?;
+        db::main::element_event::queries::insert(user.id, place_c.id, "create", &pool).await?;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool))
+                .service(scope("/").service(super::get)),
+        )
+        .await;
+
+        // Without places filter: all three events
+        let req = TestRequest::get().uri("/").to_request();
+        let res: Vec<super::ActivityItem> = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(3, res.len());
+
+        // With places filter: only matching events
+        let req = TestRequest::get()
+            .uri(&format!("/?places={},{}", place_a.id, place_c.id))
+            .to_request();
+        let res: Vec<super::ActivityItem> = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(2, res.len());
+        let place_ids: HashSet<i64> = res.iter().map(|i| i.place_id).collect();
+        assert!(place_ids.contains(&place_a.id));
+        assert!(place_ids.contains(&place_c.id));
+        assert!(!place_ids.contains(&place_b.id));
+
+        Ok(())
+    }
+
+    #[test]
+    async fn get_area_plus_place_inside_area_dedupes() -> Result<()> {
+        let pool = pool();
+        let user = db::main::osm_user::queries::insert(
+            1,
+            crate::service::osm::EditingApiUser::mock(),
+            &pool,
+        )
+        .await?;
+
+        let place_in_area =
+            db::main::element::queries::insert(OverpassElement::mock(1), &pool).await?;
+        let area =
+            db::main::area::queries::insert(db::main::area::schema::Area::mock_tags(), &pool)
+                .await?;
+        db::main::area_element::queries::insert(area.id, place_in_area.id, &pool).await?;
+
+        db::main::element_event::queries::insert(user.id, place_in_area.id, "create", &pool)
+            .await?;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool))
+                .service(scope("/").service(super::get)),
+        )
+        .await;
+
+        let req = TestRequest::get()
+            .uri(&format!("/?areas={}&places={}", area.id, place_in_area.id))
+            .to_request();
+        let res: Vec<super::ActivityItem> = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(1, res.len());
+        assert_eq!(place_in_area.id, res[0].place_id);
+        Ok(())
+    }
+
+    #[test]
+    async fn get_area_plus_place_outside_area_includes_both() -> Result<()> {
+        let pool = pool();
+        let user = db::main::osm_user::queries::insert(
+            1,
+            crate::service::osm::EditingApiUser::mock(),
+            &pool,
+        )
+        .await?;
+
+        let place_in_area =
+            db::main::element::queries::insert(OverpassElement::mock(1), &pool).await?;
+        let place_outside =
+            db::main::element::queries::insert(OverpassElement::mock(2), &pool).await?;
+        let place_ignored =
+            db::main::element::queries::insert(OverpassElement::mock(3), &pool).await?;
+
+        let area =
+            db::main::area::queries::insert(db::main::area::schema::Area::mock_tags(), &pool)
+                .await?;
+        db::main::area_element::queries::insert(area.id, place_in_area.id, &pool).await?;
+
+        db::main::element_event::queries::insert(user.id, place_in_area.id, "create", &pool)
+            .await?;
+        db::main::element_event::queries::insert(user.id, place_outside.id, "create", &pool)
+            .await?;
+        db::main::element_event::queries::insert(user.id, place_ignored.id, "create", &pool)
+            .await?;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool))
+                .service(scope("/").service(super::get)),
+        )
+        .await;
+
+        let req = TestRequest::get()
+            .uri(&format!("/?areas={}&places={}", area.id, place_outside.id))
+            .to_request();
+        let res: Vec<super::ActivityItem> = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(2, res.len());
+        let place_ids: HashSet<i64> = res.iter().map(|i| i.place_id).collect();
+        assert!(place_ids.contains(&place_in_area.id));
+        assert!(place_ids.contains(&place_outside.id));
+        assert!(!place_ids.contains(&place_ignored.id));
         Ok(())
     }
 

--- a/src/rest/v4/activity.rs
+++ b/src/rest/v4/activity.rs
@@ -26,6 +26,7 @@ const EVENT_TYPE_COMMENT: &str = "place_commented";
 const EVENT_TYPE_BOOST: &str = "place_boosted";
 
 const MAX_DAYS: i64 = 3650;
+const MAX_PLACES: usize = 500;
 
 #[derive(Deserialize)]
 pub struct GetActivityArgs {
@@ -124,6 +125,12 @@ pub async fn get(
             })?,
         None => Vec::new(),
     };
+
+    if places.len() > MAX_PLACES {
+        return Err(RestApiError::invalid_input(format!(
+            "places must contain at most {MAX_PLACES} IDs"
+        )));
+    }
 
     let mut elements: Option<HashSet<i64>> = None;
 
@@ -749,6 +756,28 @@ mod test {
         assert!(place_ids.contains(&place_in_area.id));
         assert!(place_ids.contains(&place_outside.id));
         assert!(!place_ids.contains(&place_ignored.id));
+        Ok(())
+    }
+
+    #[test]
+    async fn get_too_many_places_returns_400() -> Result<()> {
+        let pool = pool();
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool))
+                .service(scope("/").service(super::get)),
+        )
+        .await;
+
+        let ids: Vec<String> = (1..=(super::MAX_PLACES + 1))
+            .map(|n| n.to_string())
+            .collect();
+        let req = TestRequest::get()
+            .uri(&format!("/?places={}", ids.join(",")))
+            .to_request();
+        let res = test::call_service(&app, req).await;
+        assert_eq!(actix_web::http::StatusCode::BAD_REQUEST, res.status());
+
         Ok(())
     }
 

--- a/src/rest/v4/activity.rs
+++ b/src/rest/v4/activity.rs
@@ -25,6 +25,8 @@ const EVENT_TYPE_DELETE: &str = "place_deleted";
 const EVENT_TYPE_COMMENT: &str = "place_commented";
 const EVENT_TYPE_BOOST: &str = "place_boosted";
 
+const MAX_DAYS: i64 = 3650;
+
 #[derive(Deserialize)]
 pub struct GetActivityArgs {
     days: Option<i64>,
@@ -70,6 +72,11 @@ pub async fn get(
 ) -> RestResult<Vec<ActivityItem>> {
     let now = OffsetDateTime::now_utc();
     let days = args.days.unwrap_or(1);
+    if !(1..=MAX_DAYS).contains(&days) {
+        return Err(RestApiError::invalid_input(format!(
+            "days must be between 1 and {MAX_DAYS}"
+        )));
+    }
     let day_ago = now.saturating_sub(Duration::days(days));
     let period_end = now + Duration::seconds(1);
 
@@ -742,6 +749,31 @@ mod test {
         assert!(place_ids.contains(&place_in_area.id));
         assert!(place_ids.contains(&place_outside.id));
         assert!(!place_ids.contains(&place_ignored.id));
+        Ok(())
+    }
+
+    #[test]
+    async fn get_days_out_of_range_returns_400() -> Result<()> {
+        let pool = pool();
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool))
+                .service(scope("/").service(super::get)),
+        )
+        .await;
+
+        for bad in ["0", "-1", "3651", "36500"] {
+            let req = TestRequest::get()
+                .uri(&format!("/?days={bad}"))
+                .to_request();
+            let res = test::call_service(&app, req).await;
+            assert_eq!(
+                actix_web::http::StatusCode::BAD_REQUEST,
+                res.status(),
+                "days={bad} should be 400",
+            );
+        }
+
         Ok(())
     }
 

--- a/src/rest/v4/activity.rs
+++ b/src/rest/v4/activity.rs
@@ -242,7 +242,7 @@ pub async fn get(
     }
 
     // Fetch boosts — invoices store element_id in a description string,
-    // not a JOINable column, so we use the in_area() helper for filtering
+    // not a JOINable column, so we use the in_filter() helper for filtering
     let paid_invoices = db::main::invoice::queries::select_by_status(InvoiceStatus::Paid, &pool)
         .await
         .map_err(|_| RestApiError::database())?;

--- a/src/rest/v4/activity.rs
+++ b/src/rest/v4/activity.rs
@@ -117,7 +117,7 @@ pub async fn get(
         Some(comma_separated_places) => {
             if comma_separated_places.split(',').count() > MAX_PLACES {
                 return Err(RestApiError::invalid_input(format!(
-                    "places must contain at most {MAX_PLACES} IDs"
+                    "places accepts at most {MAX_PLACES} comma-separated values"
                 )));
             }
             comma_separated_places

--- a/src/rest/v4/activity.rs
+++ b/src/rest/v4/activity.rs
@@ -108,8 +108,13 @@ pub async fn get(
     let places: Vec<i64> = match &args.places {
         Some(comma_separated_places) => comma_separated_places
             .split(",")
-            .filter_map(|s| s.trim().parse::<i64>().ok())
-            .collect(),
+            .map(|s| s.trim().parse::<i64>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| {
+                RestApiError::invalid_input(
+                    "places must be a comma-separated list of integer place IDs",
+                )
+            })?,
         None => Vec::new(),
     };
 
@@ -737,6 +742,27 @@ mod test {
         assert!(place_ids.contains(&place_in_area.id));
         assert!(place_ids.contains(&place_outside.id));
         assert!(!place_ids.contains(&place_ignored.id));
+        Ok(())
+    }
+
+    #[test]
+    async fn get_invalid_places_returns_400() -> Result<()> {
+        let pool = pool();
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(pool))
+                .service(scope("/").service(super::get)),
+        )
+        .await;
+
+        let req = TestRequest::get().uri("/?places=foo").to_request();
+        let res = test::call_service(&app, req).await;
+        assert_eq!(actix_web::http::StatusCode::BAD_REQUEST, res.status());
+
+        let req = TestRequest::get().uri("/?places=1,bar,3").to_request();
+        let res = test::call_service(&app, req).await;
+        assert_eq!(actix_web::http::StatusCode::BAD_REQUEST, res.status());
+
         Ok(())
     }
 

--- a/src/rest/v4/activity.rs
+++ b/src/rest/v4/activity.rs
@@ -114,23 +114,24 @@ pub async fn get(
     }
 
     let places: HashSet<i64> = match &args.places {
-        Some(comma_separated_places) => comma_separated_places
-            .split(",")
-            .map(|s| s.trim().parse::<i64>())
-            .collect::<Result<HashSet<_>, _>>()
-            .map_err(|_| {
-                RestApiError::invalid_input(
-                    "places must be a comma-separated list of integer place IDs",
-                )
-            })?,
+        Some(comma_separated_places) => {
+            if comma_separated_places.split(',').count() > MAX_PLACES {
+                return Err(RestApiError::invalid_input(format!(
+                    "places must contain at most {MAX_PLACES} IDs"
+                )));
+            }
+            comma_separated_places
+                .split(',')
+                .map(|s| s.trim().parse::<i64>())
+                .collect::<Result<HashSet<_>, _>>()
+                .map_err(|_| {
+                    RestApiError::invalid_input(
+                        "places must be a comma-separated list of integer place IDs",
+                    )
+                })?
+        }
         None => HashSet::new(),
     };
-
-    if places.len() > MAX_PLACES {
-        return Err(RestApiError::invalid_input(format!(
-            "places must contain at most {MAX_PLACES} unique IDs"
-        )));
-    }
 
     let mut elements: Option<HashSet<i64>> = None;
 

--- a/src/rest/v4/activity.rs
+++ b/src/rest/v4/activity.rs
@@ -113,22 +113,22 @@ pub async fn get(
         }
     }
 
-    let places: Vec<i64> = match &args.places {
+    let places: HashSet<i64> = match &args.places {
         Some(comma_separated_places) => comma_separated_places
             .split(",")
             .map(|s| s.trim().parse::<i64>())
-            .collect::<Result<Vec<_>, _>>()
+            .collect::<Result<HashSet<_>, _>>()
             .map_err(|_| {
                 RestApiError::invalid_input(
                     "places must be a comma-separated list of integer place IDs",
                 )
             })?,
-        None => Vec::new(),
+        None => HashSet::new(),
     };
 
     if places.len() > MAX_PLACES {
         return Err(RestApiError::invalid_input(format!(
-            "places must contain at most {MAX_PLACES} IDs"
+            "places must contain at most {MAX_PLACES} unique IDs"
         )));
     }
 


### PR DESCRIPTION
Relates to this FE draft: https://github.com/teambtcmap/btcmap.org/pull/928


  ## What

  Adds a `?places=id1,id2,...` query param to `GET /v4/activity`, alongside
  the existing `?area=` / `?areas=` filters. Place IDs union into the
  element-filter `HashSet` so area+place overlap (e.g. saved country + a
  place inside it) dedupes to one event.

  ## Why

  The FE is building `/user/activity` — a combined activity feed across a
  signed-in user's saved places **and** saved areas. One request, server-side
  merge + dedup, stateless/cacheable (no `/users/me/activity` needed).

  ## Validation & limits

  - `places` values must parse as `i64` → otherwise `400 Invalid Input`.
  - `days` clamped to `1..=3650` → otherwise `400` (also protects the
    pre-existing unauthenticated global fetch path).
  - `places` capped at 500 unique IDs.

  ## Tests

  `cargo test activity` → 16 passing, incl. new cases for:
  - `?places=...` only (pure places filter)
  - `?areas=A&places=X` where X is inside A → deduped to 1 event
  - `?areas=A&places=X` where X is outside A → both included
  - Invalid `places`, out-of-range `days`, oversized `places` list → 400

  ## Notes

  No SQL changes, no new queries. The handler falls back from the per-area
  optimized fetch to a global fetch + post-filter whenever `places` is
  present; existing area-only callers are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering activities by specific places. Users can now query activities using comma-separated place identifiers in combination with existing area-based filters.

* **Bug Fixes**
  * Enhanced parameter validation with stricter input checks and improved error responses for invalid or out-of-range values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->