### PR TITLE
db: restore unique partial index on user.npub with preflight dedup

### DIFF
--- a/src/db/main/migrations/102.sql
+++ b/src/db/main/migrations/102.sql
@@ -1,0 +1,27 @@
+-- Restore the `user.npub` UNIQUE constraint that was originally part of
+-- the Nostr-auth work but was reverted from migration 101 to avoid a
+-- merge conflict with the multi-vendor import PR.
+--
+-- The endpoint handler in `src/rest/v4/nostr.rs` is already written to
+-- treat a `user.npub` UNIQUE violation as the lost-race recovery path
+-- for the auto-create flow. Without this index that branch is dormant
+-- and two concurrent first-time sign-ins for the same pubkey can produce
+-- two rows.
+
+-- Pre-flight: between the endpoint going live and this migration landing
+-- a small number of duplicate-npub rows could have been created. For
+-- each duplicate group keep the oldest row's npub link and NULL out the
+-- npub on the rest. The losing rows keep all their other state (saved
+-- items, existing tokens) — they just lose their Nostr identity link, so
+-- the user's next Nostr sign-in lands deterministically on the winner.
+UPDATE "user"
+SET npub = NULL
+WHERE npub IS NOT NULL
+  AND id NOT IN (
+      SELECT MIN(id)
+      FROM "user"
+      WHERE npub IS NOT NULL
+      GROUP BY npub
+  );
+
+CREATE UNIQUE INDEX user_npub_unique ON "user"(npub) WHERE npub IS NOT NULL;

--- a/src/db/main/schema.sql
+++ b/src/db/main/schema.sql
@@ -222,4 +222,5 @@ CREATE INDEX place_submission_lat_lon ON place_submission(lat, lon);
 CREATE INDEX element_deleted_at ON element(deleted_at);
 CREATE INDEX element_event_user_created_type ON element_event(user_id, created_at, type);
 CREATE INDEX area_type ON area(json_extract(tags, '$.type'));
+CREATE UNIQUE INDEX user_npub_unique ON "user"(npub) WHERE npub IS NOT NULL;
 COMMIT;


### PR DESCRIPTION
Migration 101 originally added this index as part of the Nostr-auth work (PR #89), but it was reverted in be18b50 to avoid a merge conflict with the multi-vendor import PR — the maintainer noted on the PR thread that the constraint would land in a follow-up.

This is that follow-up.

The endpoint handler in src/rest/v4/nostr.rs is already written to treat a user.npub UNIQUE violation as the lost-race recovery path for create_or_recover. Without the index, that branch is dormant and two simultaneous first-time Nostr sign-ins for the same pubkey can produce two rows.

Pre-flight (per CodeRabbit's original concern on PR #89): between the endpoint going live on 2026-05-10 and this migration landing, duplicate-npub rows are possible. For each duplicate group, keep the oldest row's npub link and NULL out the rest. Losing rows retain all other state (saved items, existing tokens) — they just lose the Nostr identity link, so the user's next Nostr sign-in lands deterministically on the winning row.

Schema bootstrap (schema.sql) updated to match.

Note: src/rest/v4/nostr.rs::unknown_npub_concurrent_inserts_create_exactly_one_user passes today for the wrong reason — :memory: SQLite gives each connection its own private DB, so the two "concurrent" inserts never share state. Worth rewriting in a separate change to actually exercise the race the index now prevents.