### PR TITLE
docs: document Nostr (NIP-98) sign-in and the BTCMAP_API_BASE_URL requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ The server binds to `http://127.0.0.1:8000`. Test it with:
 curl http://localhost:8000/v2/areas
 ```
 
+### Configuration
+
+Behavior is controlled by environment variables (all optional in local dev):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `RUST_LOG` | `info` | Log level. |
+| `BTCMAP_API_BASE_URL` | `http://127.0.0.1:8000` | Public base URL of the API. NIP-98 Nostr auth verifies the signed event's `u` tag against this value, **not** the request `Host`/`X-Forwarded-*` headers. **In production this must be set to the public origin** (e.g. `https://api.btcmap.org`) or all Nostr auth fails with `401`. See [Server Configuration (NIP-98)](docs/rest/v4/auth.md#server-configuration-nip-98). |
+| `BTCMAP_API_CORS_ORIGINS` | `*` | Comma-separated allowlist of CORS origins. `*` (or unset) allows any origin. |
+
 ### devtools
 
 The `devtools` script provides helper commands for development:

--- a/docs/rest/v4/README.md
+++ b/docs/rest/v4/README.md
@@ -5,6 +5,7 @@ The latest and recommended version of the BTCMap API, offering improved performa
 ## Endpoints  
 
 ### Implemented  
+- **[Auth](auth.md)** - Sign in with Nostr (NIP-98) to obtain a Bearer token.
 - **[Places](places.md)** - Fetch places.
 - **[Place Boosts](place-boosts.md)** - Fetch place boost quotes and submit boost intents.
 - **[Place Comments](place-comments.md)** - Fetch place comment quotes and submit comment intents.

--- a/docs/rest/v4/auth.md
+++ b/docs/rest/v4/auth.md
@@ -1,0 +1,91 @@
+# Auth REST API (v4)
+
+This document describes the authentication endpoints in REST API v4.
+
+BTC Map issues opaque Bearer tokens. A token can be obtained in two ways:
+
+- **Username + password** — see [Create Token](users.md#create-token).
+- **Nostr (NIP-98)** — sign in with a Nostr keypair, described below.
+
+Both paths mint the same kind of opaque Bearer token, sent as
+`Authorization: Bearer <token>` on subsequent requests.
+
+> [!NOTE]
+> The `/v4/auth` scope is **Nostr-specific** — it currently exposes only the
+> endpoint below. Password login is **not** under `/v4/auth`; it lives at
+> `POST /v4/users/{username}/tokens` ([Create Token](users.md#create-token)),
+> which takes the password in an `Authorization: Bearer <password>` header.
+
+## Available Endpoints
+
+- [Sign In with Nostr](#sign-in-with-nostr)
+
+## Server Configuration (NIP-98)
+
+> [!IMPORTANT]
+> Every NIP-98 endpoint (this one and [Link Nostr Identity](users.md#link-nostr-identity))
+> verifies the signed event's `u` tag against the API's **configured public
+> base URL**, taken from the `BTCMAP_API_BASE_URL` environment variable — **not**
+> from the request's `Host`/`X-Forwarded-*` headers (trusting those would let an
+> attacker replay an event signed for another host).
+
+`BTCMAP_API_BASE_URL` **must be set to the public origin clients actually call**,
+e.g.:
+
+```
+BTCMAP_API_BASE_URL=https://api.btcmap.org
+```
+
+It defaults to `http://127.0.0.1:8000` (the local dev address). If the deployed
+value does not match the origin the client signs against, the `u` tags will
+never match and **all NIP-98 requests fail with `401`** — even though the routes
+themselves are reachable. This failure is silent: there is no startup warning,
+and non-Nostr endpoints are unaffected, so a misconfigured deployment looks
+healthy until someone tries to sign in with Nostr.
+
+### Sign In with Nostr
+
+Exchanges a NIP-98 signed event for a Bearer token. If no account is linked to
+the signing pubkey yet, one is **auto-created** (random username, no password,
+`user` role, npub set) and a token is returned for it. Subsequent sign-ins with
+the same key return a token for that same account.
+
+The signed event is carried on the `Authorization` header with the `Nostr`
+scheme. The event must be a NIP-98 event (kind `27235`) that signs:
+
+- `u` = `<BTCMAP_API_BASE_URL>/v4/auth/nostr`
+- `method` = `POST`
+
+within a ±60s window of the server clock. Both `u` and `method` are matched
+case-sensitively. See [Server Configuration](#server-configuration-nip-98) above
+for what `<BTCMAP_API_BASE_URL>` resolves to.
+
+#### Example Request
+
+```bash
+curl -X POST https://api.btcmap.org/v4/auth/nostr \
+  -H "Authorization: Nostr <base64-encoded-nip98-event>"
+```
+
+#### Response
+
+| Code | Description |
+|------|-------------|
+| 200  | Success - Returns a Bearer token and the signing identity |
+| 401  | Unauthorized - Missing/invalid NIP-98 proof, or `u`/`method`/signature/timestamp mismatch |
+
+##### Example Response (200 OK)
+
+```json
+{
+  "token": "df6cfea3-6169-40ed-945f-f8e5690a1ce7",
+  "username": "exuberant-street-7342",
+  "npub": "npub1..."
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| token | String | Bearer token to send as `Authorization: Bearer <token>` on subsequent requests |
+| username | String | Username of the signed-in (or newly created) account |
+| npub  | String | Bech32 npub of the Nostr identity that signed in |

--- a/docs/rest/v4/users.md
+++ b/docs/rest/v4/users.md
@@ -266,6 +266,8 @@ Links (or replaces) the Nostr pubkey on the authenticated account. This requires
 
 The two cannot share the `Authorization` header, so the NIP-98 proof is carried on the dedicated `X-Nostr-Authorization` header. The request body is empty. The proof event must sign `u = <api-base-url>/v4/users/me/nostr` with method `PUT` (the `u`/`method` are matched against the server's configured base URL and the actual request method — both are case-sensitive).
 
+Here `<api-base-url>` is the server's configured `BTCMAP_API_BASE_URL`, not the host from the request headers. See [Server Configuration (NIP-98)](auth.md#server-configuration-nip-98) for why this must match the public origin.
+
 #### Example Request
 
 ```bash


### PR DESCRIPTION
## What

Documents two gaps in the Nostr auth surface that are currently undocumented:

1. **`POST /v4/auth/nostr` (sign in with Nostr)** — the primary Nostr login/auto-create path had no entry anywhere under `docs/`. Added `docs/rest/v4/auth.md` and linked it from the v4 README.
2. **The `BTCMAP_API_BASE_URL` deploy requirement** — every NIP-98 endpoint verifies the signed event's `u` tag against `BTCMAP_API_BASE_URL` (`src/main.rs:71`), which defaults to `http://127.0.0.1:8000`. If a deployment leaves it at the default, **all NIP-98 auth fails with `401` while the routes still look reachable** — a silent misconfiguration. This is now called out prominently.

## Why

Real-world trip-up: prod currently runs on the default base URL, so NIP-98 sign-in 401s even though `POST /v4/auth/nostr` and `/v4/users/me/nostr` are deployed and respond. The requirement was only noted in `AGENTS.md` (contributor-facing, and it framed the localhost default as benign) — nothing operator- or consumer-facing.

## Changes (docs only)

- **`docs/rest/v4/auth.md`** (new): documents `POST /v4/auth/nostr` (request, response shape `token`/`username`/`npub`, auto-create-on-first-sign-in), a `> [!IMPORTANT]` **Server Configuration (NIP-98)** callout about `BTCMAP_API_BASE_URL`, and a note clarifying the `/v4/auth` scope is Nostr-specific while password tokens come from `POST /v4/users/{username}/tokens`.
- **`docs/rest/v4/README.md`**: link the new Auth doc.
- **`docs/rest/v4/users.md`**: point the Link Nostr Identity endpoint's `<api-base-url>` at the new config section.
- **`README.md`**: add a Configuration table listing `BTCMAP_API_BASE_URL` (must equal the public origin in prod) and `BTCMAP_API_CORS_ORIGINS`.

No code changes; no `cargo fmt/clippy/test` impact (markdown only).

## For the maintainer

- The example response in `auth.md` uses a real shape observed from prod. The doc states the prod fix is to set `BTCMAP_API_BASE_URL=https://api.btcmap.org` — sanity-check the exact prod origin before merge.
- Draft until you've confirmed the wording matches how you want to frame the config requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)