### PR TITLE
docs: clarify submit_place upsert/patch behavior

### DIFF
--- a/docs/rpc/import/README.md
+++ b/docs/rpc/import/README.md
@@ -4,7 +4,7 @@ The RPC API provides a [JSON-RPC 2.0](https://www.jsonrpc.org/specification) int
 
 ## Methods
 
-- [submit_place](submit_place.md): Adds new places to the map.
+- [submit_place](submit_place.md): Adds new places to the map, or patches an existing one if `(origin, external_id)` is resubmitted.
 - [get_submitted_place](get_submitted_place.md): Fetch previous submission details.
 - [revoke_submitted_place](revoke_submitted_place.md): Cancels a pending import or reports that a place no longer accepts Bitcoin.
 

--- a/docs/rpc/import/submit_place.md
+++ b/docs/rpc/import/submit_place.md
@@ -6,6 +6,12 @@ Most BTC Map locations are sourced from [OpenStreetMap](https://www.openstreetma
 
 This RPC offers trusted external sources (major franchises, PoS providers, etc.) the ability to get on BTC Map instantly, which benefits BTC Map users and API consumers, including popular Bitcoin wallets. All imported data will also be processed by BTC Map editors and merged into OSM eventually. The merger timeline is unpredictable, as it depends on many factors beyond our control. This method allows BTC Map users to skip the wait while also making it easy for various Bitcoin merchant data sources to open-source their data and promote their merchants.
 
+### Idempotent updates (Patch-by-resubmit)
+
+`submit_place` is idempotent based on the `(origin, external_id)` pair. If you call it with the same `origin` and `external_id` as a previous submission, it will **update** the existing record in place rather than creating a duplicate. Only fields whose values actually changed (`lat`, `lon`, `category`, `name`, `extra_fields`) will be written. The record `id` stays the same — there is no separate "update" or "patch" method.
+
+If the previous submission was revoked, resubmitting will automatically un-revoke it. To revoke a submission, use [`revoke_submitted_place`](revoke_submitted_place.md) instead.
+
 ## Params
 
 ```json


### PR DESCRIPTION
Documents that `submit_place` is idempotent based on the `(origin, external_id)` pair — resubmitting updates the existing record in place rather than creating a duplicate. Also updates the import README listing to mention the patch behavior.