### PR TITLE
Search places by address and any other OSM tag

### DIFF
--- a/docs/rest/v4/README.md
+++ b/docs/rest/v4/README.md
@@ -15,6 +15,7 @@ The latest and recommended version of the BTCMap API, offering improved performa
 - **[Invoices](invoices.md)** - Check invoice status for boosts, comments and other paywalled features.
 - **[Users](users.md)** - Get authenticated user information.  
 - **[Areas](areas.md)** - Fetch areas and manage saved areas.
+- **[Search](search.md)** - Search areas and places by name, address and any other OSM tag.
 ### Proposed
 - Need something extra? Let us know!
 

--- a/docs/rest/v4/search.md
+++ b/docs/rest/v4/search.md
@@ -1,7 +1,7 @@
 # Search
 
 ```
-curl 'https://api.btcmap.org/v4/search/?q=hamburg'
+curl 'https://api.btcmap.org/v4/search/?q=prague'
 ```
 
 Searches areas and places in one call. Places match against **every OSM tag value**, so a
@@ -9,7 +9,7 @@ query for a city name finds the places whose address is in that city, and locali
 tags are searched for free. Areas match on their name and URL alias.
 
 Every whitespace-separated word must match, though different words may match different tags:
-`q=hamburg cafe` finds a place with `addr:city=Hamburg` and `cuisine=cafe`.
+`q=prague cafe` finds a place with `addr:city=Prague` and `cuisine=cafe`.
 
 ## Parameters
 
@@ -28,8 +28,8 @@ Results are ranked by an exact name match, then a name prefix match, then a name
 match, then a match on any other tag. At equal rank, areas precede places, and — when `lat`
 and `lon` are supplied — nearer places precede farther ones.
 
-Supplying `lat` and `lon` matters more than it looks. A query like `hamburg` matches thousands
-of places that no place is actually *named*, so they all share the lowest rank. Without a
+Supplying `lat` and `lon` matters more than it looks. A query like `prague` matches many
+places that no place is actually *named*, so they all share the lowest rank. Without a
 location to break the tie, the `limit` selects among them by name length.
 
 ## Examples
@@ -37,7 +37,7 @@ location to break the tie, the `limit` selects among them by name length.
 ### Find a city and the places in it
 
 ```bash
-curl 'https://api.btcmap.org/v4/search/?q=hamburg&lat=53.55&lon=9.99&limit=2'
+curl 'https://api.btcmap.org/v4/search/?q=prague&lat=50.08&lon=14.43&limit=2'
 ```
 
 ```json
@@ -46,35 +46,35 @@ curl 'https://api.btcmap.org/v4/search/?q=hamburg&lat=53.55&lon=9.99&limit=2'
     {
       "type": "area",
       "id": 123,
-      "name": "Hamburg",
-      "alias": "hamburg",
-      "bbox": [9.73, 53.39, 10.32, 53.74]
+      "name": "Prague",
+      "alias": "prague",
+      "bbox": [14.22, 49.94, 14.71, 50.18]
     },
     {
       "type": "place",
       "id": 28779,
-      "name": "Kaffeeklatsch",
-      "lat": 53.5601,
-      "lon": 9.9722,
+      "name": "Bitcoin Coffee",
+      "lat": 50.0810,
+      "lon": 14.4270,
       "icon": "local_cafe",
-      "address": "Lange Reihe 12 Hamburg 20099",
+      "address": "5 Wenceslas Square Prague 110 00",
       "created_at": "2025-09-17T08:22:03.855Z",
       "updated_at": "2025-09-18T13:12:31.723Z",
       "verified_at": "2025-09-18T00:00:00Z",
       "osm_id": "node:13149030952"
     }
   ],
-  "total_count": 1284,
+  "total_count": 512,
   "has_more": true,
-  "query": "hamburg",
-  "pagination": { "offset": 0, "limit": 2, "total": 1284 }
+  "query": "prague",
+  "pagination": { "offset": 0, "limit": 2, "total": 512 }
 }
 ```
 
 ### Restrict to places
 
 ```bash
-curl 'https://api.btcmap.org/v4/search/?q=hamburg&type_filter=place'
+curl 'https://api.btcmap.org/v4/search/?q=prague&type_filter=place'
 ```
 
 ## Result types

--- a/docs/rest/v4/search.md
+++ b/docs/rest/v4/search.md
@@ -1,0 +1,98 @@
+# Search
+
+```
+curl 'https://api.btcmap.org/v4/search/?q=hamburg'
+```
+
+Searches areas and places in one call. Places match against **every OSM tag value**, so a
+query for a city name finds the places whose address is in that city, and localized `name:*`
+tags are searched for free. Areas match on their name and URL alias.
+
+Every whitespace-separated word must match, though different words may match different tags:
+`q=hamburg cafe` finds a place with `addr:city=Hamburg` and `cuisine=cafe`.
+
+## Parameters
+
+| Parameter     | Type   | Default | Description                                                             |
+|---------------|--------|---------|-------------------------------------------------------------------------|
+| `q`           | String | -       | **Required.** At least 3 characters. At most 8 words are considered.     |
+| `lat`         | Number | -       | Optional. Breaks relevance ties by proximity. Must be paired with `lon`. |
+| `lon`         | Number | -       | Optional. Must be paired with `lat`.                                     |
+| `limit`       | Number | `20`    | Capped at 100.                                                           |
+| `offset`      | Number | `0`     | Capped at 10000.                                                         |
+| `type_filter` | String | -       | `area` or `place`. Omit to search both.                                  |
+
+## Ordering
+
+Results are ranked by an exact name match, then a name prefix match, then a name substring
+match, then a match on any other tag. At equal rank, areas precede places, and — when `lat`
+and `lon` are supplied — nearer places precede farther ones.
+
+Supplying `lat` and `lon` matters more than it looks. A query like `hamburg` matches thousands
+of places that no place is actually *named*, so they all share the lowest rank. Without a
+location to break the tie, the `limit` selects among them by name length.
+
+## Examples
+
+### Find a city and the places in it
+
+```bash
+curl 'https://api.btcmap.org/v4/search/?q=hamburg&lat=53.55&lon=9.99&limit=2'
+```
+
+```json
+{
+  "results": [
+    {
+      "type": "area",
+      "id": 123,
+      "name": "Hamburg",
+      "alias": "hamburg",
+      "bbox": [9.73, 53.39, 10.32, 53.74]
+    },
+    {
+      "type": "place",
+      "id": 28779,
+      "name": "Kaffeeklatsch",
+      "lat": 53.5601,
+      "lon": 9.9722,
+      "icon": "local_cafe",
+      "address": "Lange Reihe 12 Hamburg 20099",
+      "created_at": "2025-09-17T08:22:03.855Z",
+      "updated_at": "2025-09-18T13:12:31.723Z",
+      "verified_at": "2025-09-18T00:00:00Z",
+      "osm_id": "node:13149030952"
+    }
+  ],
+  "total_count": 1284,
+  "has_more": true,
+  "query": "hamburg",
+  "pagination": { "offset": 0, "limit": 2, "total": 1284 }
+}
+```
+
+### Restrict to places
+
+```bash
+curl 'https://api.btcmap.org/v4/search/?q=hamburg&type_filter=place'
+```
+
+## Result types
+
+Every result carries a `type` discriminator.
+
+`type: "area"` — `id`, `name`, `alias` (omitted when unset), and `bbox` as
+`[west, south, east, north]` (omitted when the area has no bounding box of its own).
+
+`type: "place"` — the same object returned by [`/v4/places/search`](places.md#search): `id`,
+`lat`, `lon`, `icon`, `name`, plus the optional `address`, `opening_hours`, `comments`,
+`verified_at`, `osm_id`, `phone`, `website`, `localized_name` and friends.
+
+## Notes
+
+Matching is a case-insensitive substring test over ASCII. Diacritics are not folded, so
+`q=cafe` does not match `Café`.
+
+Because every tag value is searchable, a query for a value that most places carry — `q=yes`
+matches every `payment:*=yes` tag — returns a very large `total_count`. Use `limit` and
+`offset`.

--- a/src/db/main/area/blocking_queries.rs
+++ b/src/db/main/area/blocking_queries.rs
@@ -1,9 +1,12 @@
 use super::schema;
 use super::schema::Area;
 use super::schema::Columns;
+use crate::service::search::{escape_like, split_words};
 use crate::Result;
 use geojson::GeoJson;
 use rusqlite::params;
+use rusqlite::params_from_iter;
+use rusqlite::types::Value as SqlValue;
 use rusqlite::Connection;
 use serde_json::{Map, Value};
 use time::format_description::well_known::Rfc3339;
@@ -498,6 +501,114 @@ pub fn select_top_areas_by_type(conn: &Connection, area_type: &str) -> Result<Ve
     Ok(results)
 }
 
+/// The `bbox_*` columns default to the whole world, which is indistinguishable
+/// from "never set". Reported as `None` rather than inviting a client to fly the
+/// map to the entire planet.
+const WORLD_BBOX: [f64; 4] = [-180.0, -90.0, 180.0, 90.0];
+
+#[derive(Debug, PartialEq)]
+pub struct RankedArea {
+    pub id: i64,
+    pub name: String,
+    pub alias: Option<String>,
+    pub bbox: Option<[f64; 4]>,
+    pub rank: i64,
+}
+
+/// Matches name and alias only. An area's `tags` hold its full `geo_json`
+/// polygon, so matching tag values here would substring-match coordinate digits.
+fn search_predicate(word_count: usize, first_word_param: usize) -> String {
+    let name = format!("json_extract({}, '$.name')", Columns::Tags.as_str());
+    let alias = Columns::Alias.as_str();
+    let mut words = String::new();
+    for i in 0..word_count {
+        let param = first_word_param + i;
+        words.push_str(&format!(
+            r#"
+            AND ({name} LIKE ?{param} ESCAPE '\' OR {alias} LIKE ?{param} ESCAPE '\')"#
+        ));
+    }
+    format!(
+        "{deleted_at} IS NULL AND {name} IS NOT NULL{words}",
+        deleted_at = Columns::DeletedAt.as_str(),
+    )
+}
+
+fn word_patterns(words: &[String]) -> impl Iterator<Item = SqlValue> + '_ {
+    words
+        .iter()
+        .map(|word| SqlValue::Text(format!("%{}%", escape_like(word))))
+}
+
+pub fn select_by_search(query: &str, row_limit: i64, conn: &Connection) -> Result<Vec<RankedArea>> {
+    let words = split_words(query);
+    let name = format!("json_extract({}, '$.name')", Columns::Tags.as_str());
+    let sql = format!(
+        r#"
+            SELECT {id}, {alias}, {bbox_west}, {bbox_south}, {bbox_east}, {bbox_north},
+                   {name} AS name,
+              CASE
+                WHEN {name} = ?1 COLLATE NOCASE THEN 0
+                WHEN {name} LIKE ?2 ESCAPE '\' THEN 1
+                WHEN {name} LIKE ?3 ESCAPE '\' THEN 2
+                ELSE 3
+              END AS search_rank
+            FROM {table}
+            WHERE {predicate}
+            ORDER BY search_rank, LENGTH(name), name
+            LIMIT ?4
+        "#,
+        id = Columns::Id.as_str(),
+        alias = Columns::Alias.as_str(),
+        bbox_west = Columns::BboxWest.as_str(),
+        bbox_south = Columns::BboxSouth.as_str(),
+        bbox_east = Columns::BboxEast.as_str(),
+        bbox_north = Columns::BboxNorth.as_str(),
+        table = schema::TABLE_NAME,
+        predicate = search_predicate(words.len(), 5),
+    );
+
+    let escaped = escape_like(query);
+    let mut values = vec![
+        SqlValue::Text(query.to_string()),
+        SqlValue::Text(format!("{escaped}%")),
+        SqlValue::Text(format!("%{escaped}%")),
+        SqlValue::Integer(row_limit),
+    ];
+    values.extend(word_patterns(&words));
+
+    conn.prepare(&sql)?
+        .query_map(params_from_iter(values), |row| {
+            let bbox = [
+                row.get::<_, f64>(Columns::BboxWest.as_str())?,
+                row.get::<_, f64>(Columns::BboxSouth.as_str())?,
+                row.get::<_, f64>(Columns::BboxEast.as_str())?,
+                row.get::<_, f64>(Columns::BboxNorth.as_str())?,
+            ];
+            Ok(RankedArea {
+                id: row.get(Columns::Id.as_str())?,
+                name: row.get("name")?,
+                alias: row.get(Columns::Alias.as_str())?,
+                bbox: (bbox != WORLD_BBOX).then_some(bbox),
+                rank: row.get("search_rank")?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+pub fn count_by_search(query: &str, conn: &Connection) -> Result<i64> {
+    let words = split_words(query);
+    let sql = format!(
+        "SELECT COUNT(*) FROM {table} WHERE {predicate}",
+        table = schema::TABLE_NAME,
+        predicate = search_predicate(words.len(), 1),
+    );
+    let values: Vec<SqlValue> = word_patterns(&words).collect();
+    conn.query_row(&sql, params_from_iter(values), |row| row.get(0))
+        .map_err(Into::into)
+}
+
 #[cfg(test)]
 mod test {
     use super::schema::Area;
@@ -718,6 +829,119 @@ mod test {
         let conn = conn();
         let area = super::insert(Area::mock_tags(), &conn)?;
         assert_eq!(area.tags["url_alias"], area.alias());
+        Ok(())
+    }
+
+    fn insert_named_area(
+        name: &str,
+        alias: &str,
+        geo_json: serde_json::Value,
+        conn: &rusqlite::Connection,
+    ) -> Area {
+        let mut tags = Map::new();
+        tags.insert("name".into(), serde_json::Value::String(name.into()));
+        tags.insert("url_alias".into(), serde_json::Value::String(alias.into()));
+        tags.insert("geo_json".into(), geo_json);
+        super::insert(tags, conn).unwrap()
+    }
+
+    fn point_geo_json(lon: f64, lat: f64) -> serde_json::Value {
+        json!({
+            "type": "Feature",
+            "properties": {},
+            "geometry": { "type": "Point", "coordinates": [lon, lat] }
+        })
+    }
+
+    fn area_search(query: &str, conn: &rusqlite::Connection) -> Vec<i64> {
+        super::select_by_search(query, 100, conn)
+            .unwrap()
+            .into_iter()
+            .map(|it| it.id)
+            .collect()
+    }
+
+    #[test]
+    fn area_search_matches_name() -> Result<()> {
+        let conn = conn();
+        let hit = insert_named_area("Hamburg", "hamburg", point_geo_json(9.99, 53.55), &conn);
+        insert_named_area("Berlin", "berlin", point_geo_json(13.4, 52.5), &conn);
+        assert_eq!(vec![hit.id], area_search("hamburg", &conn));
+        Ok(())
+    }
+
+    #[test]
+    fn area_search_matches_alias() -> Result<()> {
+        let conn = conn();
+        let hit = insert_named_area(
+            "Grand Paris",
+            "grand-paris",
+            point_geo_json(2.35, 48.85),
+            &conn,
+        );
+        assert_eq!(vec![hit.id], area_search("grand-paris", &conn));
+        Ok(())
+    }
+
+    #[test]
+    fn area_search_never_matches_geo_json() -> Result<()> {
+        let conn = conn();
+        insert_named_area("Hamburg", "hamburg", point_geo_json(9.99, 53.55), &conn);
+        // "9.9" appears in the polygon coordinates but nowhere in name or alias.
+        assert!(area_search("9.9", &conn).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn area_search_requires_all_words() -> Result<()> {
+        let conn = conn();
+        let hit = insert_named_area(
+            "Grand Paris",
+            "grand-paris",
+            point_geo_json(2.35, 48.85),
+            &conn,
+        );
+        assert_eq!(vec![hit.id], area_search("grand paris", &conn));
+        assert!(area_search("grand tokyo", &conn).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn area_search_reports_world_bbox_as_none() -> Result<()> {
+        let conn = conn();
+        insert_named_area("Hamburg", "hamburg", point_geo_json(9.99, 53.55), &conn);
+        let ranked = super::select_by_search("hamburg", 100, &conn)?;
+        // `insert` does not populate bbox columns, so they keep the world defaults.
+        assert_eq!(None, ranked[0].bbox);
+        assert_eq!(Some("hamburg".to_string()), ranked[0].alias);
+        Ok(())
+    }
+
+    #[test]
+    fn area_search_ranks_exact_name_first() -> Result<()> {
+        let conn = conn();
+        let exact = insert_named_area("Hamburg", "hamburg", point_geo_json(9.99, 53.55), &conn);
+        let prefix = insert_named_area(
+            "Hamburg Nord",
+            "hamburg-nord",
+            point_geo_json(9.99, 53.6),
+            &conn,
+        );
+        assert_eq!(vec![exact.id, prefix.id], area_search("hamburg", &conn));
+        Ok(())
+    }
+
+    #[test]
+    fn count_by_search_counts_all_matches() -> Result<()> {
+        let conn = conn();
+        insert_named_area("Hamburg", "hamburg", point_geo_json(9.99, 53.55), &conn);
+        insert_named_area(
+            "Hamburg Nord",
+            "hamburg-nord",
+            point_geo_json(9.99, 53.6),
+            &conn,
+        );
+        assert_eq!(2, super::count_by_search("hamburg", &conn)?);
         Ok(())
     }
 }

--- a/src/db/main/area/blocking_queries.rs
+++ b/src/db/main/area/blocking_queries.rs
@@ -555,7 +555,7 @@ pub fn select_by_search(query: &str, row_limit: i64, conn: &Connection) -> Resul
               END AS search_rank
             FROM {table}
             WHERE {predicate}
-            ORDER BY search_rank, LENGTH(name), name
+            ORDER BY search_rank, LENGTH(name), name, {id}
             LIMIT ?4
         "#,
         id = Columns::Id.as_str(),

--- a/src/db/main/area/queries.rs
+++ b/src/db/main/area/queries.rs
@@ -163,3 +163,23 @@ pub async fn select_top_areas_by_type(pool: &Pool, area_type: &str) -> Result<Ve
         .interact(move |conn| blocking_queries::select_top_areas_by_type(conn, &area_type))
         .await?
 }
+
+pub use super::blocking_queries::RankedArea;
+
+pub async fn select_by_search(
+    query: String,
+    row_limit: i64,
+    pool: &Pool,
+) -> Result<Vec<RankedArea>> {
+    pool.get()
+        .await?
+        .interact(move |conn| blocking_queries::select_by_search(&query, row_limit, conn))
+        .await?
+}
+
+pub async fn count_by_search(query: String, pool: &Pool) -> Result<i64> {
+    pool.get()
+        .await?
+        .interact(move |conn| blocking_queries::count_by_search(&query, conn))
+        .await?
+}

--- a/src/db/main/element/blocking_queries.rs
+++ b/src/db/main/element/blocking_queries.rs
@@ -1,7 +1,9 @@
 use super::schema::{self, Columns, Element};
 use crate::db::main::area_element::schema::{self as area_element_schema};
+use crate::service::search::{escape_like, split_words};
 use crate::{service::overpass::OverpassElement, Result};
-use rusqlite::{named_params, params, Connection};
+use rusqlite::types::Value as SqlValue;
+use rusqlite::{named_params, params, params_from_iter, Connection};
 use serde_json::{Map, Value};
 use time::{format_description::well_known::Rfc3339, Date, OffsetDateTime};
 
@@ -450,8 +452,134 @@ pub fn set_deleted_at(
     select_by_id(id, conn)
 }
 
+#[derive(Debug, PartialEq)]
+pub struct RankedElement {
+    pub element: Element,
+    pub rank: i64,
+}
+
+/// Shared predicate for both the select and the count. `first_word_param` is the
+/// 1-based index of the first `?N` placeholder that holds a word pattern, so the
+/// two callers can bind different numbers of leading parameters.
+///
+/// `json_type(...) = 'object'` guards `json_each` against a NULL argument for
+/// elements with no tags: SQLite does not promise `WHERE`-clause evaluation
+/// order, so the `name IS NOT NULL` check cannot be relied on to shield it.
+fn tag_value_predicate(word_count: usize, first_word_param: usize) -> String {
+    let mut words = String::new();
+    for i in 0..word_count {
+        words.push_str(&format!(
+            r#"
+            AND EXISTS (
+                SELECT 1 FROM json_each(json_extract({table}.{overpass_data}, '$.tags')) t
+                WHERE t.type = 'text' AND t.value LIKE ?{param} ESCAPE '\'
+            )"#,
+            table = schema::TABLE_NAME,
+            overpass_data = Columns::OverpassData.as_str(),
+            param = first_word_param + i,
+        ));
+    }
+    format!(
+        r#"{deleted_at} IS NULL
+            AND {lat} IS NOT NULL
+            AND {lon} IS NOT NULL
+            AND json_type({overpass_data}, '$.tags') = 'object'
+            AND json_extract({overpass_data}, '$.tags.name') IS NOT NULL{words}"#,
+        deleted_at = Columns::DeletedAt.as_str(),
+        lat = Columns::Lat.as_str(),
+        lon = Columns::Lon.as_str(),
+        overpass_data = Columns::OverpassData.as_str(),
+    )
+}
+
+fn word_patterns(words: &[String]) -> impl Iterator<Item = SqlValue> + '_ {
+    words
+        .iter()
+        .map(|word| SqlValue::Text(format!("%{}%", escape_like(word))))
+}
+
+/// Matches `query` against every OSM tag **value** (never a key), requiring every
+/// word to match some value. Ranks exact name hits above prefix, above infix,
+/// above a hit on any other tag. `location` breaks rank ties by proximity.
+pub fn select_by_tag_value_search(
+    query: &str,
+    location: Option<(f64, f64)>,
+    row_limit: i64,
+    conn: &Connection,
+) -> Result<Vec<RankedElement>> {
+    let words = split_words(query);
+    let name = format!(
+        "json_extract({}, '$.tags.name')",
+        Columns::OverpassData.as_str()
+    );
+    let sql = format!(
+        r#"
+            SELECT {projection},
+              CASE
+                WHEN {name} = ?1 COLLATE NOCASE THEN 0
+                WHEN {name} LIKE ?2 ESCAPE '\' THEN 1
+                WHEN {name} LIKE ?3 ESCAPE '\' THEN 2
+                ELSE 3
+              END AS search_rank
+            FROM {table}
+            WHERE {predicate}
+            ORDER BY search_rank,
+                     CASE WHEN ?6 = 1
+                          THEN ({lat} - ?4) * ({lat} - ?4) + ({lon} - ?5) * ({lon} - ?5)
+                          ELSE 0 END,
+                     LENGTH({name}),
+                     {name}
+            LIMIT ?7
+        "#,
+        projection = Element::projection(),
+        table = schema::TABLE_NAME,
+        predicate = tag_value_predicate(words.len(), 8),
+        lat = Columns::Lat.as_str(),
+        lon = Columns::Lon.as_str(),
+    );
+
+    let escaped = escape_like(query);
+    let (lat, lon, has_location) = match location {
+        Some((lat, lon)) => (lat, lon, 1),
+        None => (0.0, 0.0, 0),
+    };
+    let mut values = vec![
+        SqlValue::Text(query.to_string()),
+        SqlValue::Text(format!("{escaped}%")),
+        SqlValue::Text(format!("%{escaped}%")),
+        SqlValue::Real(lat),
+        SqlValue::Real(lon),
+        SqlValue::Integer(has_location),
+        SqlValue::Integer(row_limit),
+    ];
+    values.extend(word_patterns(&words));
+
+    conn.prepare(&sql)?
+        .query_map(params_from_iter(values), |row| {
+            Ok(RankedElement {
+                element: Element::mapper()(row)?,
+                rank: row.get("search_rank")?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+pub fn count_by_tag_value_search(query: &str, conn: &Connection) -> Result<i64> {
+    let words = split_words(query);
+    let sql = format!(
+        "SELECT COUNT(*) FROM {table} WHERE {predicate}",
+        table = schema::TABLE_NAME,
+        predicate = tag_value_predicate(words.len(), 1),
+    );
+    let values: Vec<SqlValue> = word_patterns(&words).collect();
+    conn.query_row(&sql, params_from_iter(values), |row| row.get(0))
+        .map_err(Into::into)
+}
+
 #[cfg(test)]
 mod test {
+    use super::schema::Element;
     use crate::db::main::test::conn;
     use crate::service::overpass::OverpassElement;
     use crate::Error;
@@ -768,5 +896,213 @@ mod test {
         let element2 = super::insert(&OverpassElement::mock(2), &conn).unwrap();
         let result = super::select_by_ids(&[element1.id, element2.id], &conn).unwrap();
         assert_eq!(2, result.len());
+    }
+
+    fn insert_place(
+        id: i64,
+        tags: &[(&str, &str)],
+        lat: f64,
+        lon: f64,
+        conn: &rusqlite::Connection,
+    ) -> Element {
+        let element = super::insert(&OverpassElement::mock_with_tags(id, tags), conn).unwrap();
+        super::set_lat_lon(element.id, lat, lon, conn).unwrap()
+    }
+
+    fn search(query: &str, conn: &rusqlite::Connection) -> Vec<Element> {
+        super::select_by_tag_value_search(query, None, 100, conn)
+            .unwrap()
+            .into_iter()
+            .map(|it| it.element)
+            .collect()
+    }
+
+    #[test]
+    fn tag_value_search_matches_address_city() -> Result<()> {
+        let conn = conn();
+        let hit = insert_place(
+            1,
+            &[("name", "Kaffeeklatsch"), ("addr:city", "Hamburg")],
+            53.5,
+            9.9,
+            &conn,
+        );
+        insert_place(
+            2,
+            &[("name", "Elsewhere"), ("addr:city", "Berlin")],
+            52.5,
+            13.4,
+            &conn,
+        );
+        assert_eq!(vec![hit], search("hamburg", &conn));
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_matches_localized_name() -> Result<()> {
+        let conn = conn();
+        let hit = insert_place(
+            1,
+            &[("name", "Kaffeeklatsch"), ("name:ja", "カフェ")],
+            53.5,
+            9.9,
+            &conn,
+        );
+        assert_eq!(vec![hit], search("カフェ", &conn));
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_never_matches_tag_keys() -> Result<()> {
+        let conn = conn();
+        insert_place(
+            1,
+            &[("name", "Kaffeeklatsch"), ("addr:city", "Hamburg")],
+            53.5,
+            9.9,
+            &conn,
+        );
+        assert!(search("addr", &conn).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_skips_unnamed_elements() -> Result<()> {
+        let conn = conn();
+        insert_place(1, &[("addr:city", "Hamburg")], 53.5, 9.9, &conn);
+        assert!(search("hamburg", &conn).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_skips_elements_without_coordinates() -> Result<()> {
+        let conn = conn();
+        // Inserted but never given lat/lon: `SearchedPlace::from` would panic on it.
+        super::insert(
+            &OverpassElement::mock_with_tags(1, &[("name", "Hamburg Cafe")]),
+            &conn,
+        )?;
+        assert!(search("hamburg", &conn).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_skips_elements_without_tags() -> Result<()> {
+        let conn = conn();
+        let element = super::insert(&OverpassElement::mock(1), &conn)?;
+        super::set_lat_lon(element.id, 53.5, 9.9, &conn)?;
+        // `mock` has an empty tag map; must not blow up json_each.
+        assert!(search("hamburg", &conn).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_requires_all_words() -> Result<()> {
+        let conn = conn();
+        let hit = insert_place(
+            1,
+            &[
+                ("name", "Kaffeeklatsch"),
+                ("addr:city", "Hamburg"),
+                ("cuisine", "cafe"),
+            ],
+            53.5,
+            9.9,
+            &conn,
+        );
+        insert_place(
+            2,
+            &[("name", "Nordsee"), ("addr:city", "Hamburg")],
+            53.6,
+            9.8,
+            &conn,
+        );
+        // Words may match different tags on the same element.
+        assert_eq!(vec![hit], search("hamburg cafe", &conn));
+        // A word that matches nothing kills the whole row.
+        assert!(search("hamburg sushi", &conn).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_escapes_like_wildcards() -> Result<()> {
+        let conn = conn();
+        let hit = insert_place(1, &[("name", "100% Coffee")], 53.5, 9.9, &conn);
+        insert_place(2, &[("name", "Nordsee")], 53.6, 9.8, &conn);
+        // Unescaped, '%100%%' would match every row.
+        assert_eq!(vec![hit], search("100%", &conn));
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_excludes_deleted() -> Result<()> {
+        let conn = conn();
+        let element = insert_place(1, &[("name", "Hamburg Cafe")], 53.5, 9.9, &conn);
+        super::set_deleted_at(element.id, Some(OffsetDateTime::now_utc()), &conn)?;
+        assert!(search("hamburg", &conn).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_ranks_name_above_other_tags() -> Result<()> {
+        let conn = conn();
+        let exact = insert_place(1, &[("name", "Hamburg")], 53.5, 9.9, &conn);
+        let prefix = insert_place(2, &[("name", "Hamburger Grill")], 53.5, 9.9, &conn);
+        let infix = insert_place(3, &[("name", "Cafe Hamburg Nord")], 53.5, 9.9, &conn);
+        let other = insert_place(
+            4,
+            &[("name", "Nordsee"), ("addr:city", "Hamburg")],
+            53.5,
+            9.9,
+            &conn,
+        );
+        assert_eq!(vec![exact, prefix, infix, other], search("hamburg", &conn));
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_breaks_rank_ties_by_distance() -> Result<()> {
+        let conn = conn();
+        let far = insert_place(
+            1,
+            &[("name", "Nordsee"), ("addr:city", "Hamburg")],
+            60.0,
+            9.9,
+            &conn,
+        );
+        let near = insert_place(
+            2,
+            &[("name", "Kaffeeklatsch"), ("addr:city", "Hamburg")],
+            53.6,
+            9.9,
+            &conn,
+        );
+        let ranked = super::select_by_tag_value_search("hamburg", Some((53.5, 9.9)), 100, &conn)?;
+        let ids: Vec<i64> = ranked.into_iter().map(|it| it.element.id).collect();
+        assert_eq!(vec![near.id, far.id], ids);
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_honours_row_limit() -> Result<()> {
+        let conn = conn();
+        for id in 1..=5 {
+            insert_place(id, &[("name", &format!("Hamburg {id}"))], 53.5, 9.9, &conn);
+        }
+        assert_eq!(
+            2,
+            super::select_by_tag_value_search("hamburg", None, 2, &conn)?.len()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn count_by_tag_value_search_counts_all_matches() -> Result<()> {
+        let conn = conn();
+        for id in 1..=5 {
+            insert_place(id, &[("name", &format!("Hamburg {id}"))], 53.5, 9.9, &conn);
+        }
+        assert_eq!(5, super::count_by_tag_value_search("hamburg", &conn)?);
+        Ok(())
     }
 }

--- a/src/db/main/element/blocking_queries.rs
+++ b/src/db/main/element/blocking_queries.rs
@@ -528,7 +528,8 @@ pub fn select_by_tag_value_search(
                           THEN ({lat} - ?4) * ({lat} - ?4) + ({lon} - ?5) * ({lon} - ?5)
                           ELSE 0 END,
                      LENGTH({name}),
-                     {name}
+                     {name},
+                     {id}
             LIMIT ?7
         "#,
         projection = Element::projection(),
@@ -536,6 +537,7 @@ pub fn select_by_tag_value_search(
         predicate = tag_value_predicate(words.len(), 8),
         lat = Columns::Lat.as_str(),
         lon = Columns::Lon.as_str(),
+        id = Columns::Id.as_str(),
     );
 
     let escaped = escape_like(query);

--- a/src/db/main/element/blocking_queries.rs
+++ b/src/db/main/element/blocking_queries.rs
@@ -508,9 +508,15 @@ pub fn select_by_tag_value_search(
     conn: &Connection,
 ) -> Result<Vec<RankedElement>> {
     let words = split_words(query);
+    // Rank and order on the same name the response shows — `name(Some("en"))`,
+    // i.e. name:en when present, else the raw name. Ranking on the raw name while
+    // displaying name:en both mis-ranks localized matches and, because the DB
+    // order must equal the in-memory merge order for the reslice to be correct,
+    // could drop a row at a page boundary. The `IS NOT NULL` gate in the
+    // predicate stays on the raw name, so this COALESCE is never null.
     let name = format!(
-        "json_extract({}, '$.tags.name')",
-        Columns::OverpassData.as_str()
+        r#"COALESCE(NULLIF(json_extract({od}, '$.tags."name:en"'), ''), json_extract({od}, '$.tags.name'))"#,
+        od = Columns::OverpassData.as_str(),
     );
     let sql = format!(
         r#"
@@ -1095,6 +1101,30 @@ mod test {
             2,
             super::select_by_tag_value_search("hamburg", None, 2, &conn)?.len()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn tag_value_search_ranks_by_localized_name() -> Result<()> {
+        let conn = conn();
+        // Raw name doesn't match "cafe", but the displayed name (name:en) is an
+        // exact match. It must rank as exact (0), above a prefix hit, not be
+        // demoted to an other-tag hit (3) because the raw name was consulted.
+        let localized_exact = insert_place(
+            1,
+            &[("name", "Kaffee"), ("name:en", "Cafe")],
+            53.5,
+            9.9,
+            &conn,
+        );
+        let prefix = insert_place(2, &[("name", "Cafe Central")], 53.6, 9.8, &conn);
+        let ranked = super::select_by_tag_value_search("cafe", None, 100, &conn)?;
+        let by_id: std::collections::HashMap<i64, i64> =
+            ranked.iter().map(|r| (r.element.id, r.rank)).collect();
+        assert_eq!(Some(&0), by_id.get(&localized_exact.id));
+        assert_eq!(Some(&1), by_id.get(&prefix.id));
+        // Exact localized match sorts first.
+        assert_eq!(localized_exact.id, ranked[0].element.id);
         Ok(())
     }
 

--- a/src/db/main/element/queries.rs
+++ b/src/db/main/element/queries.rs
@@ -206,3 +206,26 @@ pub async fn set_deleted_at(
         .interact(move |conn| blocking_queries::set_deleted_at(id, deleted_at, conn))
         .await?
 }
+
+pub use super::blocking_queries::RankedElement;
+
+pub async fn select_by_tag_value_search(
+    query: String,
+    location: Option<(f64, f64)>,
+    row_limit: i64,
+    pool: &Pool,
+) -> Result<Vec<RankedElement>> {
+    pool.get()
+        .await?
+        .interact(move |conn| {
+            blocking_queries::select_by_tag_value_search(&query, location, row_limit, conn)
+        })
+        .await?
+}
+
+pub async fn count_by_tag_value_search(query: String, pool: &Pool) -> Result<i64> {
+    pool.get()
+        .await?
+        .interact(move |conn| blocking_queries::count_by_tag_value_search(&query, conn))
+        .await?
+}

--- a/src/rest/v4/search.rs
+++ b/src/rest/v4/search.rs
@@ -1,9 +1,16 @@
 use crate::db;
+use crate::db::main::area::queries::RankedArea;
+use crate::db::main::element::queries::RankedElement;
 use crate::db::main::MainPool;
 use crate::rest::error::RestResult as Res;
 use crate::rest::error::{RestApiError, RestApiErrorCode};
+use crate::rest::v4::places::SearchedPlace;
 use actix_web::{get, web::Data, web::Json, web::Query};
 use serde::{Deserialize, Serialize};
+
+const MIN_QUERY_LEN: usize = 3;
+const MAX_LIMIT: i64 = 100;
+const MAX_OFFSET: i64 = 10_000;
 
 #[derive(Deserialize)]
 pub struct SearchArgs {
@@ -12,21 +19,37 @@ pub struct SearchArgs {
     pub limit: i64,
     #[serde(default)]
     pub offset: i64,
-    pub type_filter: Option<String>, // "area", "element", or none
+    pub lat: Option<f64>,
+    pub lon: Option<f64>,
+    /// `area` or `place`. Omit for both.
+    pub type_filter: Option<String>,
 }
 
 fn default_limit() -> i64 {
     20
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-pub struct SearchResult {
-    pub name: String,
-    pub r#type: String,
+#[derive(Serialize)]
+pub struct SearchedArea {
     pub id: i64,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    /// `[west, south, east, north]`. Absent when the area has no bbox of its own.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bbox: Option<[f64; 4]>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+/// `SearchedPlace` is boxed because it is an order of magnitude larger than
+/// `SearchedArea`, and clippy's `large_enum_variant` would otherwise fire.
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SearchResult {
+    Area(SearchedArea),
+    Place(Box<SearchedPlace>),
+}
+
+#[derive(Serialize)]
 pub struct SearchResponse {
     pub results: Vec<SearchResult>,
     pub total_count: u32,
@@ -35,199 +58,408 @@ pub struct SearchResponse {
     pub pagination: PaginationInfo,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize)]
 pub struct PaginationInfo {
     pub offset: i64,
     pub limit: i64,
     pub total: u32,
 }
 
-// GET /search?q=query&limit=10&offset=0&type_filter=area
+/// One candidate row plus its global sort key. Areas carry `kind = 0` so they
+/// precede places at equal rank; `distance` only ever applies to places.
+struct Ranked {
+    rank: i64,
+    kind: u8,
+    distance: f64,
+    name_len: usize,
+    name: String,
+    result: SearchResult,
+}
+
+// GET /v4/search?q=hamburg&lat=53.5&lon=9.9&limit=20&offset=0&type_filter=place
 #[get("")]
 pub async fn get(args: Query<SearchArgs>, pool: Data<MainPool>) -> Res<SearchResponse> {
-    // query validation
-    let query = args.q.trim();
-    if query.is_empty() {
+    let query = args.q.trim().to_string();
+    if query.chars().count() < MIN_QUERY_LEN {
         return Err(RestApiError::new(
             RestApiErrorCode::InvalidInput,
-            "Search query cannot be empty",
+            "Search query must be at least 3 characters long",
         ));
     }
 
-    // minimal query length
-    if query.len() < 2 {
-        return Err(RestApiError::new(
-            RestApiErrorCode::InvalidInput,
-            "Search query must be at least 2 characters long",
-        ));
-    }
-
-    // maximal length
-    let limit = args.limit.min(100);
-    let offset = args.offset.max(0);
-
-    let mut results = Vec::new();
-
-    // search areas by default or if specified
-    if args.type_filter.is_none() || args.type_filter.as_deref() == Some("area") {
-        let areas = db::main::area::queries::select_by_search_query(query, &pool)
-            .await
-            .map_err(|_| RestApiError::database())?;
-
-        for area in areas {
-            results.push(SearchResult {
-                name: area.name(),
-                r#type: "area".to_string(),
-                id: area.id,
-            });
+    let (want_area, want_place) = match args.type_filter.as_deref() {
+        None => (true, true),
+        Some("area") => (true, false),
+        Some("place") => (false, true),
+        Some(_) => {
+            return Err(RestApiError::new(
+                RestApiErrorCode::InvalidInput,
+                "type_filter must be 'area' or 'place'",
+            ))
         }
-    }
-
-    // search elements by default or if specified
-    if args.type_filter.is_none() || args.type_filter.as_deref() == Some("element") {
-        let elements = db::main::element::queries::select_by_search_query(query, false, &pool)
-            .await
-            .map_err(|_| RestApiError::database())?;
-
-        for element in elements {
-            results.push(SearchResult {
-                name: element.name(None),
-                r#type: "element".to_string(),
-                id: element.id,
-            });
-        }
-    }
-
-    // relevance sort
-    results.sort_by(|a, b| {
-        let a_exact = a.name.to_lowercase().starts_with(&query.to_lowercase());
-        let b_exact = b.name.to_lowercase().starts_with(&query.to_lowercase());
-        match (a_exact, b_exact) {
-            (true, false) => std::cmp::Ordering::Less,
-            (false, true) => std::cmp::Ordering::Greater,
-            _ => a.name.cmp(&b.name),
-        }
-    });
-
-    // pagination
-    let total = results.len() as u32;
-    let start = offset as usize;
-    let end = (start + limit as usize).min(results.len());
-    let paginated_results = if start < results.len() {
-        results[start..end].to_vec()
-    } else {
-        Vec::new()
     };
 
-    let response = SearchResponse {
-        results: paginated_results,
+    let location = match (args.lat, args.lon) {
+        (Some(lat), Some(lon)) => Some((lat, lon)),
+        (None, None) => None,
+        _ => {
+            return Err(RestApiError::new(
+                RestApiErrorCode::InvalidInput,
+                "lat and lon must be provided together",
+            ))
+        }
+    };
+
+    let limit = args.limit.clamp(1, MAX_LIMIT);
+    let offset = args.offset.clamp(0, MAX_OFFSET);
+    // Each side returns its own top `offset + limit`. Merging two lists sorted by
+    // the same key and re-slicing yields exactly the global page.
+    let row_limit = offset + limit;
+
+    let mut ranked: Vec<Ranked> = Vec::new();
+    let mut total: i64 = 0;
+
+    if want_area {
+        let areas = db::main::area::queries::select_by_search(query.clone(), row_limit, &pool)
+            .await
+            .map_err(|_| RestApiError::database())?;
+        total += db::main::area::queries::count_by_search(query.clone(), &pool)
+            .await
+            .map_err(|_| RestApiError::database())?;
+        for area in areas {
+            let RankedArea {
+                id,
+                name,
+                alias,
+                bbox,
+                rank,
+            } = area;
+            ranked.push(Ranked {
+                rank,
+                kind: 0,
+                distance: 0.0,
+                name_len: name.chars().count(),
+                name: name.clone(),
+                result: SearchResult::Area(SearchedArea {
+                    id,
+                    name,
+                    alias,
+                    bbox,
+                }),
+            });
+        }
+    }
+
+    if want_place {
+        let elements = db::main::element::queries::select_by_tag_value_search(
+            query.clone(),
+            location,
+            row_limit,
+            &pool,
+        )
+        .await
+        .map_err(|_| RestApiError::database())?;
+        total += db::main::element::queries::count_by_tag_value_search(query.clone(), &pool)
+            .await
+            .map_err(|_| RestApiError::database())?;
+        for ranked_element in elements {
+            let RankedElement { element, rank } = ranked_element;
+            // The query filters NULL coordinates, so these defaults never apply.
+            let distance = match location {
+                Some((lat, lon)) => {
+                    let place_lat = element.lat.unwrap_or(0.0);
+                    let place_lon = element.lon.unwrap_or(0.0);
+                    (place_lat - lat).powi(2) + (place_lon - lon).powi(2)
+                }
+                None => 0.0,
+            };
+            let place: SearchedPlace = element.into();
+            let name = place.name.clone();
+            ranked.push(Ranked {
+                rank,
+                kind: 1,
+                distance,
+                name_len: name.chars().count(),
+                name,
+                result: SearchResult::Place(Box::new(place)),
+            });
+        }
+    }
+
+    ranked.sort_by(|a, b| {
+        a.rank
+            .cmp(&b.rank)
+            .then(a.kind.cmp(&b.kind))
+            .then(a.distance.total_cmp(&b.distance))
+            .then(a.name_len.cmp(&b.name_len))
+            .then(a.name.cmp(&b.name))
+    });
+
+    let results: Vec<SearchResult> = ranked
+        .into_iter()
+        .skip(offset as usize)
+        .take(limit as usize)
+        .map(|it| it.result)
+        .collect();
+
+    let total = total.max(0) as u32;
+
+    Ok(Json(SearchResponse {
+        results,
         total_count: total,
         has_more: (offset + limit) < total as i64,
-        query: query.to_string(),
+        query,
         pagination: PaginationInfo {
             offset,
             limit,
             total,
         },
-    };
-
-    Ok(Json(response))
+    }))
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use crate::db;
     use crate::db::main::test::pool;
+    use crate::db::main::MainPool;
     use crate::service::overpass::OverpassElement;
-    use crate::{db, Result};
+    use crate::Result;
     use actix_web::test::TestRequest;
     use actix_web::web::{scope, Data};
     use actix_web::{test, App};
+    use serde_json::{json, Map, Value};
+
+    macro_rules! app {
+        ($pool:expr) => {
+            test::init_service(
+                App::new()
+                    .app_data(Data::new($pool))
+                    .service(scope("/search").service(super::get)),
+            )
+            .await
+        };
+    }
+
+    async fn insert_place(id: i64, tags: &[(&str, &str)], lat: f64, lon: f64, pool: &MainPool) {
+        let element =
+            db::main::element::queries::insert(OverpassElement::mock_with_tags(id, tags), pool)
+                .await
+                .unwrap();
+        db::main::element::queries::set_lat_lon(element.id, lat, lon, pool)
+            .await
+            .unwrap();
+    }
+
+    async fn insert_area(name: &str, alias: &str, pool: &MainPool) {
+        let mut tags = Map::new();
+        tags.insert("name".into(), Value::String(name.into()));
+        tags.insert("url_alias".into(), Value::String(alias.into()));
+        tags.insert(
+            "geo_json".into(),
+            json!({"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[9.99,53.55]}}),
+        );
+        db::main::area::queries::insert(tags, pool).await.unwrap();
+    }
+
+    async fn status(uri: &str, pool: MainPool) -> u16 {
+        let app = app!(pool);
+        let res = test::call_service(&app, TestRequest::get().uri(uri).to_request()).await;
+        res.status().as_u16()
+    }
 
     #[test]
-    async fn search_empty_query_returns_400() -> Result<()> {
-        let app = test::init_service(
-            App::new()
-                .app_data(Data::new(pool()))
-                .service(scope("/search").service(super::get)),
-        )
-        .await;
-        let req = TestRequest::get().uri("/search?q=").to_request();
-        let res = test::call_service(&app, req).await;
-        assert_eq!(res.status(), 400);
+    async fn rejects_short_query() -> Result<()> {
+        assert_eq!(400, status("/search?q=ab", pool()).await);
         Ok(())
     }
 
     #[test]
-    async fn search_too_short_returns_400() -> Result<()> {
-        let app = test::init_service(
-            App::new()
-                .app_data(Data::new(pool()))
-                .service(scope("/search").service(super::get)),
-        )
-        .await;
-        let req = TestRequest::get().uri("/search?q=a").to_request();
-        let res = test::call_service(&app, req).await;
-        assert_eq!(res.status(), 400);
+    async fn rejects_empty_query() -> Result<()> {
+        assert_eq!(400, status("/search?q=", pool()).await);
         Ok(())
     }
 
     #[test]
-    async fn search_valid_query_returns_results() -> Result<()> {
+    async fn rejects_unknown_type_filter() -> Result<()> {
+        assert_eq!(
+            400,
+            status("/search?q=hamburg&type_filter=element", pool()).await
+        );
+        Ok(())
+    }
+
+    #[test]
+    async fn rejects_lat_without_lon() -> Result<()> {
+        assert_eq!(400, status("/search?q=hamburg&lat=53.5", pool()).await);
+        Ok(())
+    }
+
+    #[test]
+    async fn finds_places_by_address() -> Result<()> {
         let pool = pool();
-        let _element = db::main::element::queries::insert(OverpassElement::mock(1), &pool).await?;
-        let app = test::init_service(
-            App::new()
-                .app_data(Data::new(pool))
-                .service(scope("/search").service(super::get)),
+        insert_place(
+            1,
+            &[("name", "Kaffeeklatsch"), ("addr:city", "Hamburg")],
+            53.5,
+            9.9,
+            &pool,
         )
         .await;
-        let req = TestRequest::get().uri("/search?q=cuba").to_request();
-        let res: SearchResponse = test::call_and_read_body_json(&app, req).await;
-        assert_eq!(res.query, "cuba");
-        assert!(res.results.is_empty());
-        Ok(())
-    }
-
-    #[test]
-    async fn search_with_pagination_works() -> Result<()> {
-        let pool = pool();
-        for i in 1..=5 {
-            let _element =
-                db::main::element::queries::insert(OverpassElement::mock(i), &pool).await?;
-        }
-        let app = test::init_service(
-            App::new()
-                .app_data(Data::new(pool))
-                .service(scope("/search").service(super::get)),
+        insert_place(
+            2,
+            &[("name", "Nordsee"), ("addr:city", "Berlin")],
+            52.5,
+            13.4,
+            &pool,
         )
         .await;
+        let app = app!(pool);
         let req = TestRequest::get()
-            .uri("/search?q=test&limit=2&offset=0")
+            .uri("/search?q=hamburg&type_filter=place")
             .to_request();
-        let res: SearchResponse = test::call_and_read_body_json(&app, req).await;
-        assert_eq!(res.pagination.limit, 2);
-        assert_eq!(res.pagination.offset, 0);
-        assert!(res.results.len() <= 2);
+        let res: Value = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(1, res["results"].as_array().unwrap().len());
+        assert_eq!("place", res["results"][0]["type"]);
+        assert_eq!("Kaffeeklatsch", res["results"][0]["name"]);
+        assert_eq!(1, res["total_count"]);
         Ok(())
     }
 
     #[test]
-    async fn search_with_type_filter_element_only() -> Result<()> {
+    async fn place_rows_carry_coordinates_and_icon() -> Result<()> {
         let pool = pool();
-        let app = test::init_service(
-            App::new()
-                .app_data(Data::new(pool))
-                .service(scope("/search").service(super::get)),
+        insert_place(
+            1,
+            &[("name", "Kaffeeklatsch"), ("addr:city", "Hamburg")],
+            53.5,
+            9.9,
+            &pool,
         )
         .await;
+        let app = app!(pool);
         let req = TestRequest::get()
-            .uri("/search?q=test&type_filter=element")
+            .uri("/search?q=hamburg&type_filter=place")
             .to_request();
-        let res: SearchResponse = test::call_and_read_body_json(&app, req).await;
-        for result in res.results {
-            assert_eq!(result.r#type, "element");
+        let res: Value = test::call_and_read_body_json(&app, req).await;
+        let row = &res["results"][0];
+        assert_eq!(53.5, row["lat"]);
+        assert_eq!(9.9, row["lon"]);
+        assert!(row["icon"].is_string());
+        Ok(())
+    }
+
+    #[test]
+    async fn areas_precede_places_at_equal_rank() -> Result<()> {
+        let pool = pool();
+        insert_area("Hamburg", "hamburg", &pool).await;
+        insert_place(1, &[("name", "Hamburg")], 53.5, 9.9, &pool).await;
+        let app = app!(pool);
+        let req = TestRequest::get().uri("/search?q=hamburg").to_request();
+        let res: Value = test::call_and_read_body_json(&app, req).await;
+        assert_eq!("area", res["results"][0]["type"]);
+        assert_eq!("place", res["results"][1]["type"]);
+        assert_eq!(2, res["total_count"]);
+        Ok(())
+    }
+
+    #[test]
+    async fn area_rows_carry_alias() -> Result<()> {
+        let pool = pool();
+        insert_area("Hamburg", "hamburg", &pool).await;
+        let app = app!(pool);
+        let req = TestRequest::get()
+            .uri("/search?q=hamburg&type_filter=area")
+            .to_request();
+        let res: Value = test::call_and_read_body_json(&app, req).await;
+        assert_eq!("hamburg", res["results"][0]["alias"]);
+        Ok(())
+    }
+
+    #[test]
+    async fn type_filter_area_excludes_places() -> Result<()> {
+        let pool = pool();
+        insert_area("Hamburg", "hamburg", &pool).await;
+        insert_place(
+            1,
+            &[("name", "Kaffeeklatsch"), ("addr:city", "Hamburg")],
+            53.5,
+            9.9,
+            &pool,
+        )
+        .await;
+        let app = app!(pool);
+        let req = TestRequest::get()
+            .uri("/search?q=hamburg&type_filter=area")
+            .to_request();
+        let res: Value = test::call_and_read_body_json(&app, req).await;
+        for row in res["results"].as_array().unwrap() {
+            assert_eq!("area", row["type"]);
         }
+        assert_eq!(1, res["total_count"]);
+        Ok(())
+    }
+
+    #[test]
+    async fn paginates_over_a_stable_order() -> Result<()> {
+        let pool = pool();
+        for id in 1..=5 {
+            insert_place(
+                id,
+                &[
+                    ("name", "Hamburg"),
+                    ("addr:street", &format!("Street {id}")),
+                ],
+                53.5,
+                9.9,
+                &pool,
+            )
+            .await;
+        }
+        let app = app!(pool);
+
+        let req = TestRequest::get()
+            .uri("/search?q=hamburg&limit=2&offset=0")
+            .to_request();
+        let first: Value = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(2, first["results"].as_array().unwrap().len());
+        assert_eq!(5, first["total_count"]);
+        assert_eq!(true, first["has_more"]);
+
+        let req = TestRequest::get()
+            .uri("/search?q=hamburg&limit=2&offset=4")
+            .to_request();
+        let last: Value = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(1, last["results"].as_array().unwrap().len());
+        assert_eq!(false, last["has_more"]);
+        Ok(())
+    }
+
+    #[test]
+    async fn nearer_place_wins_a_rank_tie() -> Result<()> {
+        let pool = pool();
+        insert_place(
+            1,
+            &[("name", "Far"), ("addr:city", "Hamburg")],
+            60.0,
+            9.9,
+            &pool,
+        )
+        .await;
+        insert_place(
+            2,
+            &[("name", "Near"), ("addr:city", "Hamburg")],
+            53.6,
+            9.9,
+            &pool,
+        )
+        .await;
+        let app = app!(pool);
+        let req = TestRequest::get()
+            .uri("/search?q=hamburg&lat=53.5&lon=9.9")
+            .to_request();
+        let res: Value = test::call_and_read_body_json(&app, req).await;
+        assert_eq!("Near", res["results"][0]["name"]);
+        assert_eq!("Far", res["results"][1]["name"]);
         Ok(())
     }
 }

--- a/src/rest/v4/search.rs
+++ b/src/rest/v4/search.rs
@@ -66,13 +66,18 @@ pub struct PaginationInfo {
 }
 
 /// One candidate row plus its global sort key. Areas carry `kind = 0` so they
-/// precede places at equal rank; `distance` only ever applies to places.
+/// precede places at equal rank; `distance` only ever applies to places. `id` is
+/// the final, unique tiebreaker so the merged order is total and identical
+/// between the independent SQL runs that serve consecutive pages — without it,
+/// rows tied on every other key can shuffle and be skipped or duplicated across
+/// page boundaries. It mirrors the `id` term each side's SQL `ORDER BY` ends on.
 struct Ranked {
     rank: i64,
     kind: u8,
     distance: f64,
     name_len: usize,
     name: String,
+    id: i64,
     result: SearchResult,
 }
 
@@ -140,6 +145,7 @@ pub async fn get(args: Query<SearchArgs>, pool: Data<MainPool>) -> Res<SearchRes
                 distance: 0.0,
                 name_len: name.chars().count(),
                 name: name.clone(),
+                id,
                 result: SearchResult::Area(SearchedArea {
                     id,
                     name,
@@ -175,12 +181,14 @@ pub async fn get(args: Query<SearchArgs>, pool: Data<MainPool>) -> Res<SearchRes
             };
             let place: SearchedPlace = element.into();
             let name = place.name.clone();
+            let id = place.id;
             ranked.push(Ranked {
                 rank,
                 kind: 1,
                 distance,
                 name_len: name.chars().count(),
                 name,
+                id,
                 result: SearchResult::Place(Box::new(place)),
             });
         }
@@ -193,6 +201,7 @@ pub async fn get(args: Query<SearchArgs>, pool: Data<MainPool>) -> Res<SearchRes
             .then(a.distance.total_cmp(&b.distance))
             .then(a.name_len.cmp(&b.name_len))
             .then(a.name.cmp(&b.name))
+            .then(a.id.cmp(&b.id))
     });
 
     let results: Vec<SearchResult> = ranked
@@ -431,6 +440,36 @@ mod test {
         let last: Value = test::call_and_read_body_json(&app, req).await;
         assert_eq!(1, last["results"].as_array().unwrap().len());
         assert_eq!(false, last["has_more"]);
+        Ok(())
+    }
+
+    #[test]
+    async fn pagination_covers_every_row_exactly_once() -> Result<()> {
+        let pool = pool();
+        // Every place shares name, rank and distance, so only the `id` tiebreaker
+        // makes the order total. Without it, consecutive pages are independent SQL
+        // runs whose tied rows can reshuffle, skipping or duplicating a row.
+        for id in 1..=5 {
+            insert_place(id, &[("name", "Hamburg")], 53.5, 9.9, &pool).await;
+        }
+        let app = app!(pool);
+
+        let mut seen = Vec::new();
+        for offset in 0..5 {
+            let req = TestRequest::get()
+                .uri(&format!(
+                    "/search?q=hamburg&type_filter=place&limit=1&offset={offset}"
+                ))
+                .to_request();
+            let page: Value = test::call_and_read_body_json(&app, req).await;
+            let rows = page["results"].as_array().unwrap();
+            assert_eq!(1, rows.len(), "page at offset {offset}");
+            seen.push(rows[0]["id"].as_i64().unwrap());
+        }
+
+        seen.sort_unstable();
+        // Every id 1..=5, each exactly once — no skips, no duplicates.
+        assert_eq!(vec![1, 2, 3, 4, 5], seen);
         Ok(())
     }
 

--- a/src/rest/v4/search.rs
+++ b/src/rest/v4/search.rs
@@ -29,6 +29,15 @@ fn default_limit() -> i64 {
     20
 }
 
+/// Whether a reachable next page exists. `offset` is clamped to `MAX_OFFSET`, so
+/// the next page (`offset + limit`) is only reachable when it, too, is within the
+/// cap. Without the cap check, `has_more` stays `true` past the cap while the
+/// clamp keeps returning the same page — an infinite pagination loop.
+fn has_next_page(offset: i64, limit: i64, total: i64) -> bool {
+    let next_offset = offset + limit;
+    next_offset < total && next_offset <= MAX_OFFSET
+}
+
 #[derive(Serialize)]
 pub struct SearchedArea {
     pub id: i64,
@@ -216,7 +225,7 @@ pub async fn get(args: Query<SearchArgs>, pool: Data<MainPool>) -> Res<SearchRes
     Ok(Json(SearchResponse {
         results,
         total_count: total,
-        has_more: (offset + limit) < total as i64,
+        has_more: has_next_page(offset, limit, total as i64),
         query,
         pagination: PaginationInfo {
             offset,
@@ -228,6 +237,7 @@ pub async fn get(args: Query<SearchArgs>, pool: Data<MainPool>) -> Res<SearchRes
 
 #[cfg(test)]
 mod test {
+    use super::{has_next_page, MAX_OFFSET};
     use crate::db;
     use crate::db::main::test::pool;
     use crate::db::main::MainPool;
@@ -237,6 +247,19 @@ mod test {
     use actix_web::web::{scope, Data};
     use actix_web::{test, App};
     use serde_json::{json, Map, Value};
+
+    #[test]
+    async fn has_next_page_stops_at_the_offset_cap() {
+        // Plenty of rows remain, but the next page would be past the cap, where
+        // the clamp would just re-serve the current page. Must report no more.
+        assert!(!has_next_page(MAX_OFFSET, 20, 25_000));
+        assert!(!has_next_page(MAX_OFFSET - 10, 20, 25_000));
+        // Next page lands exactly on the cap — still reachable.
+        assert!(has_next_page(MAX_OFFSET - 20, 20, 25_000));
+        // Ordinary cases well within the cap.
+        assert!(has_next_page(0, 20, 25_000));
+        assert!(!has_next_page(0, 20, 15));
+    }
 
     macro_rules! app {
         ($pool:expr) => {

--- a/src/rest/v4/search.rs
+++ b/src/rest/v4/search.rs
@@ -220,7 +220,9 @@ pub async fn get(args: Query<SearchArgs>, pool: Data<MainPool>) -> Res<SearchRes
         .map(|it| it.result)
         .collect();
 
-    let total = total.max(0) as u32;
+    // Saturating conversion: `total` is bounded by the table size in practice, but
+    // clamp rather than let `as u32` silently wrap if a count ever exceeds u32::MAX.
+    let total = total.clamp(0, u32::MAX as i64) as u32;
 
     Ok(Json(SearchResponse {
         results,

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -15,6 +15,7 @@ pub mod og;
 pub mod osm;
 pub mod overpass;
 pub mod ppq;
+pub mod search;
 pub mod sync;
 pub mod user;
 pub mod wallet;

--- a/src/service/overpass.rs
+++ b/src/service/overpass.rs
@@ -161,6 +161,30 @@ impl OverpassElement {
     }
 
     #[cfg(test)]
+    pub fn mock_with_tags(id: i64, tags: &[(&str, &str)]) -> OverpassElement {
+        let mut map = Map::new();
+        for (name, value) in tags {
+            map.insert((*name).into(), (*value).into());
+        }
+        OverpassElement {
+            r#type: "node".into(),
+            id,
+            lat: Some(0.0),
+            lon: Some(0.0),
+            timestamp: Some("".into()),
+            version: Some(1),
+            changeset: Some(1),
+            user: Some("".into()),
+            uid: Some(1),
+            tags: Some(map),
+            bounds: None,
+            nodes: None,
+            geometry: None,
+            members: None,
+        }
+    }
+
+    #[cfg(test)]
     pub fn mock_with_tag(id: i64, tag_name: &str, tag_value: &str) -> OverpassElement {
         let mut tags = Map::new();
         tags.insert(tag_name.into(), tag_value.into());

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -1,0 +1,58 @@
+pub const MAX_WORDS: usize = 8;
+
+/// Escapes SQLite `LIKE` metacharacters. Patterns built from this **must** be
+/// used with `ESCAPE '\'`, otherwise a query of `%` matches every row.
+pub fn escape_like(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if matches!(ch, '\\' | '%' | '_') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+/// Splits a query into at most [`MAX_WORDS`] whitespace-separated words. The cap
+/// bounds the number of correlated subqueries a single request can generate.
+pub fn split_words(query: &str) -> Vec<String> {
+    query
+        .split_whitespace()
+        .take(MAX_WORDS)
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::{escape_like, split_words, MAX_WORDS};
+
+    #[test]
+    fn escape_like_escapes_wildcards() {
+        assert_eq!("100\\%", escape_like("100%"));
+        assert_eq!("a\\_b", escape_like("a_b"));
+        assert_eq!("a\\\\b", escape_like("a\\b"));
+        assert_eq!("hamburg", escape_like("hamburg"));
+    }
+
+    #[test]
+    fn escape_like_preserves_non_ascii() {
+        assert_eq!("café", escape_like("café"));
+    }
+
+    #[test]
+    fn split_words_splits_on_whitespace_and_trims() {
+        assert_eq!(vec!["hamburg", "cafe"], split_words("  hamburg   cafe "));
+    }
+
+    #[test]
+    fn split_words_caps_word_count() {
+        let query = "a b c d e f g h i j k";
+        assert_eq!(MAX_WORDS, split_words(query).len());
+    }
+
+    #[test]
+    fn split_words_on_empty_query_is_empty() {
+        assert!(split_words("   ").is_empty());
+    }
+}

--- a/src/service/wallet.rs
+++ b/src/service/wallet.rs
@@ -95,10 +95,7 @@ fn xpub_balance(client: &mut Client, xpub: &str) -> Result<i64> {
         }
     }
 
-    let refs: Vec<&electrum_client::bitcoin::Script> = scripts
-        .iter()
-        .map(|s| s.as_ref())
-        .collect();
+    let refs: Vec<&electrum_client::bitcoin::Script> = scripts.iter().map(|s| s.as_ref()).collect();
     let balances = client.batch_script_get_balance(&refs)?;
     let mut total: i64 = 0;
     for balance in balances {


### PR DESCRIPTION
Rebuilds the undocumented `GET /v4/search` into an omnisearch over areas and places.
Searching `hamburg` now returns the Hamburg area **and** the places whose `addr:city` is
Hamburg. Localized `name:*` tags are searched for free.

This is the server-side version of the client-side search `btcmap.org` ran until 2025-07-31,
which matched `Object.values(tags)` — every OSM tag value, never a key. It was removed in
`01127138` during the v4 Places migration and never replaced; the API has only ever matched
`$.tags.name`.

Per @bubelov's steer in chat: `/v4/places/search` stays scoped to places and is **not
touched**; the omnisearch lives on the global endpoint.

### What changed

- Places match every OSM tag **value** via `json_each` — never a key, so `q=addr` matches
  nothing. All query words must match, each possibly in a different tag, so `q=hamburg cafe`
  means a place with `addr:city=Hamburg` *and* `cuisine=cafe`. (The old client-side version
  was an any-word OR.)
- Ranking: exact name > name prefix > name substring > any other tag. Areas precede places at
  equal rank. Optional `lat`/`lon` break remaining ties by proximity — this matters, because
  a query like `hamburg` leaves thousands of places tied at the lowest rank.
- Ranking, `LIMIT` and `OFFSET` moved into SQL. The handler previously loaded **every** match
  into a `Vec<Element>` before slicing 20 rows — untenable once `q=yes` matches every
  `payment:*=yes` place. Each side fetches its own top `offset+limit`; the handler merges.
- Areas match name and alias only. Their `tags` hold the full `geo_json` polygon, so matching
  tag values there would substring-match coordinate digits.
- Area rows now carry `bbox`, so a client can fly the map to a city. The world-rectangle
  default is reported as absent rather than inviting a zoom-to-planet.
- Documented at `docs/rest/v4/search.md`. It was previously undocumented.

### Compatibility

- `GET /v4/places/search` is **unchanged**.
- JSON-RPC `search` is **unchanged**. The new matching lives in new DB functions, so
  btcmap-admin's area picker is unaffected. `git diff` touches zero lines in `src/rpc/search.rs`
  and adds/removes zero lines mentioning `select_by_search_query`.
- The `type` discriminator for a place changes from `"element"` to `"place"`, matching v4
  naming. Safe: no client calls this endpoint.

### Defects fixed in passing

- **`LIKE` wildcards were never escaped**, so `q=%` matched every row.
- `LOWER(x) LIKE UPPER(?)` only ever worked because SQLite's `LIKE` is already
  ASCII-case-insensitive; the two cancel each other's intent.
- `SearchedPlace::from` does `it.lat.unwrap()` and panics on an element with NULL
  coordinates. The new query excludes them. (The same latent panic remains on
  `/v4/places/search` — out of scope here.)
- Area search deserialised every matching `geo_json` polygon into a `serde_json::Map`.

The first commit reformats `src/service/wallet.rs`. It is unrelated, but `rustfmt` on current
stable reformats `xpub_balance` and `cargo fmt -- --check` fails on master without it.

### Known limitations

- `q=cafe` does not match `Café`. SQLite's `LIKE` folds ASCII case only and there is no ICU
  collation; the old client-side `toLowerCase()` had the identical limitation. Fixing it means
  FTS5 with `unicode61 remove_diacritics=2`.
- Still a leading-wildcard full table scan, as before. All-value matching multiplies the
  per-row cost by the tag count. FTS5 over a precomputed search document is the fix if it bites.
- Matching every tag value is deliberate — it is the behaviour that ran for three years. It
  does mean `q=yes` matches every `payment:*=yes` place and `q=2025` every `check_date`.

### Verification

`cargo fmt --check`, `cargo clippy -- -D warnings` and `cargo test` all pass (537 tests).
31 new tests. Also exercised against a running server with seeded data: `q=hamburg` returns
the area then the places; `q=hamburg cafe` narrows to one; `q=addr` and `q=%%%` return
nothing; `q=ハンブルク` matches a `name:ja` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)