### PR TITLE
fix: tolerate purged elements in trending areas query

### DIFF
--- a/src/service/area.rs
+++ b/src/service/area.rs
@@ -208,7 +208,13 @@ pub async fn get_trending_areas(
             .await?;
     let mut areas_to_events: HashMap<i64, Vec<&ElementEvent>> = HashMap::new();
     for event in &events {
-        let element = db::main::element::queries::select_by_id(event.element_id, pool).await?;
+        // Elements can be purged after their events were recorded, so a
+        // missing element should not fail the whole query
+        let element = match db::main::element::queries::select_by_id(event.element_id, pool).await {
+            Ok(element) => element,
+            Err(crate::Error::Rusqlite(rusqlite::Error::QueryReturnedNoRows)) => continue,
+            Err(err) => return Err(err),
+        };
         let element_area_ids: Vec<i64> =
             db::main::area_element::queries::select_by_element_id(element.id, pool)
                 .await?
@@ -230,7 +236,13 @@ pub async fn get_trending_areas(
         .collect();
     let mut areas_to_comments: HashMap<i64, Vec<&ElementComment>> = HashMap::new();
     for comment in &comments {
-        let element = db::main::element::queries::select_by_id(comment.element_id, pool).await?;
+        // Same as above: skip comments whose element was purged
+        let element = match db::main::element::queries::select_by_id(comment.element_id, pool).await
+        {
+            Ok(element) => element,
+            Err(crate::Error::Rusqlite(rusqlite::Error::QueryReturnedNoRows)) => continue,
+            Err(err) => return Err(err),
+        };
         let element_area_ids: Vec<i64> =
             db::main::area_element::queries::select_by_element_id(element.id, pool)
                 .await?


### PR DESCRIPTION
## Problem

`get_trending_countries` and `get_trending_communities` fail with `Query returned no rows` for any period that contains events whose element was later **purged** (hard-deleted) from the `element` table.

In `get_trending_areas`, each event/comment triggers a `select_by_id` on the element table; one missing row aborts the entire request. This made the July 2026 monthly stats unqueryable: any range touching July 9, 18, or 31 failed — including the full month and both half-month splits (the previously documented workaround).

Example (full July 2026):
```
RPC Error: {'code': -32000, 'message': 'Server error', 'data': 'Query returned no rows'}
```

## Fix

Skip events and comments whose element no longer exists instead of erroring the whole query. Only `rusqlite::Error::QueryReturnedNoRows` is swallowed; genuine database errors still propagate.

## Verification

- `cargo fmt --check` clean
- `cargo clippy -- -D warnings` clean
- `cargo test` — 628 passed, 0 failed

## Note (out of scope)

The same unguarded `select_by_id(...)?` pattern exists in `rest/v4/activity.rs`, where a purged element would similarly 500 the activity feed. Happy to follow up with a separate PR for that if desired.